### PR TITLE
Add variant: frontend-base

### DIFF
--- a/template-test/ci-run.sh
+++ b/template-test/ci-run.sh
@@ -12,7 +12,11 @@ rm -rf template-test/dummy/$TEST_NAME
 cd template-test/dummy
 
 # Pipe newlines to `rails new` to accept defaults
-yes '<enter>' | rails new $TEST_NAME -m $TEMPLATE -d postgresql 
+rails new $TEST_NAME -d postgresql -m $TEMPLATE <<OPTIONS
+example.com
+staging.example.com
+n
+OPTIONS
 
 cd $ROOT
 

--- a/template.rb
+++ b/template.rb
@@ -33,7 +33,6 @@ def apply_template!
   apply "public/template.rb"
   apply "spec/template.rb"
 
-  apply "variants/accessibility/template.rb"
 
   #apply "variants/bootstrap/template.rb" if apply_bootstrap?
 
@@ -48,6 +47,10 @@ def apply_template!
   run_with_clean_bundler_env "bin/setup"
   run_with_clean_bundler_env "bin/rails webpacker:install"
   create_initial_migration
+
+  # Apply variants after setup and initial install, but before commit
+  apply "variants/accessibility/template.rb"
+  apply "variants/frontend-base/template.rb"
 
   binstubs = %w[
     brakeman bundler bundler-audit rubocop sidekiq

--- a/variants/accessibility/Gemfile.rb
+++ b/variants/accessibility/Gemfile.rb
@@ -1,5 +1,6 @@
 insert_into_file "Gemfile", after: /gem "webdrivers"\n/ do
   <<~GEMS
+  
     gem "lighthouse-matchers"
     gem "axe-matchers"
   GEMS

--- a/variants/accessibility/Gemfile.rb
+++ b/variants/accessibility/Gemfile.rb
@@ -1,7 +1,9 @@
 insert_into_file "Gemfile", after: /gem "webdrivers"\n/ do
   <<~GEMS
-  
+
     gem "lighthouse-matchers"
     gem "axe-matchers"
   GEMS
 end
+
+run "bundle install"

--- a/variants/frontend-base/bin/sass-lint
+++ b/variants/frontend-base/bin/sass-lint
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+# vi ft:ruby
+
+rails_root = File.absolute_path(File.join(__dir__, ".."))
+cmd = "#{rails_root}/node_modules/.bin/sass-lint -c #{rails_root}/.sass-lint.yml -v -q --max-warnings 1"
+result = system cmd
+exit(false) unless result

--- a/variants/frontend-base/config/template.rb
+++ b/variants/frontend-base/config/template.rb
@@ -1,0 +1,1 @@
+gsub_file "config/webpacker.yml", "source_path: app/javascript", "source_path: app/frontend"

--- a/variants/frontend-base/sass-lint.yml
+++ b/variants/frontend-base/sass-lint.yml
@@ -1,0 +1,33 @@
+files:
+  include: "**/*.s+(a|c)ss"
+  ignore:
+    - "app/assets/stylesheets/foundation_and_overrides.scss"
+    - "app/assets/stylesheets/_settings.scss"
+    - "node_modules/**/*"
+options:
+  formatter: stylish
+  # Default rules are visible at
+  #
+  #   https://github.com/sasstools/sass-lint/blob/develop/lib/config/sass-lint.yml
+  #
+  # We choose to accept them and tweak them in the 'rules' section below
+  merge-default-rules: true
+
+rules:
+  leading-zero:
+    - 1
+    - include: true
+  quotes:
+    - 1
+    - style: double
+  class-name-format:
+    - 1
+    - convention: hyphenatedbem
+  final-newline:
+    - 0
+  nesting-depth:
+    - 1
+    - max-depth: 3
+  no-vendor-prefixes: 0
+  no-color-literals: 0
+  placeholder-in-extend: 0

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -1,0 +1,20 @@
+source_paths.unshift(File.dirname(__FILE__))
+
+run "mv app/assets/* app/frontend"
+run "mv app/javascript app/frontend"
+apply "config/template.rb"
+
+# SASS Linting
+run "yarn add --dev sass-lint"
+copy_file "bin/sass-lint"
+chmod "bin/sass-lint", "+x"
+copy_file "sass-lint.yml", ".sass-lint.yml"
+append_to_file "bin/ci-test-pipeline-1" do
+  <<~SASSLINT
+  
+  echo "* ******************************************************"
+  echo "* Running SCSS linting"
+  echo "* ******************************************************"
+  ./bin/sass-lint
+  SASSLINT
+end


### PR DESCRIPTION
This base variant sets up webpacker the way we like it `app/frontend` instead of `app/assets` and SASS-lint (including CI).

I have mixed feelings about including sass-lint.yml in the template. Should we pull it in from rabid-dotfiles?