### PR TITLE
Add reference Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+tmp
+log
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM ruby
 
 # Avoid issues with file encoding in Ruby by setting these two environment variables
 # This tells the underlying OS to expect UTF-8 encoding (e.g. UTF-8 encoding in the US language)
-ENV LANG "C"
-ENV LC_ALL C.UTF-8
+ENV LANG=C \
+    LC_ALL=C.UTF-8 \
 
 
 # Curl is installed to make it possible to set up PPAs below - it is

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ USER deploy
 ADD Gemfile* package.json yarn.lock /usr/src/app/
 WORKDIR /usr/src/app
 RUN bundle check || bundle install &&\
-    yarn check || yarn install
+    yarn check || yarn install --frozen-lockfile
 
 # Add all application code to /usr/src/app and set this as the working directory
 # of the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Pull from the latest Ruby version
+# We don't use slim or alpine variants as we invariably need build tooling, which
+# the base image includes for us.
+FROM ruby
+
+# Avoid issues with file encoding in Ruby by setting these two environment variables
+# This tells the underlying OS to expect en_US-UTF-8 encoding (e.g. UTF-8 encoding in the US language)
+ENV LANG "C"
+ENV LC_ALL en_US.UTF-8
+
+
+# Curl is installed to make it possible to set up PPAs below - it is
+# removed further down.
+RUN apt-get update -qq &&\
+    apt-get install -y curl 
+
+# Install Node.js PPA for asset management
+# As of writing, Node 10 is the most recent LTS.
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash &&\
+    apt-get update -qq && apt-get install -y nodejs
+
+# Install Google Chrome. Chrome is required for headless system tests.
+RUN curl -q https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -y google-chrome-stable --no-install-recommends
+
+# Install system dependencies, and remove curl now that we have PPAs set up
+RUN apt-get update -qq &&\
+    apt-get install google-chrome libpq-dev nodejs --no-install-recommends &&\
+    apt-get purge -y curl &&
+    rm -rf /var/lib/apt/lists/*
+
+# Create a directory to hold application code
+# We do this at this point so we can set this as the home directory of
+# the 'deploy' user.
+RUN mkdir /usr/src/app
+
+# Create a non-privileged deploy user, and add all application code as this user.
+RUN adduser --disabled-password --gecos "" deploy && chown -R deploy:deploy /usr/src/app
+USER deploy
+
+# Add all application code to /usr/src/app and set this as the working directory
+# of the container
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+
+# Install gem and NPM dependencies. These are baked into the image so the image can run
+# standalone provided valid configuration. When running in docker-compose, these 
+# dependencies are stored in a volume so the image does not need rebuilding when the
+# dependencies are changed.
+RUN bundle install
+RUN npm ci
+
+# Default command is to start a Puma server
+CMD bundle exec rails server --binding=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM ruby
 # This tells the underlying OS to expect UTF-8 encoding (e.g. UTF-8 encoding in the US language)
 ENV LANG=C \
     LC_ALL=C.UTF-8 \
+    PORT=3000
 
 
 # Curl is installed to make it possible to set up PPAs below - it is
@@ -63,6 +64,8 @@ RUN bundle check || bundle install &&\
 # Add all application code to /usr/src/app and set this as the working directory
 # of the container
 ADD . /usr/src/app
+
+EXPOSE $PORT
 
 # Default command is to start a Puma server
 CMD bundle exec rails server --binding=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,41 @@
 version: "2"
-services:
-  app: &rails
+x-services:
+  rails: &rails
     build: .
     environment:
       PGHOST: "db"
       PGUSER: "postgres"
-    links:
-      - db
     env_file: 
       - .env
     volumes:
-      - ".:/usr/src/app"
-      - node_modules:/usr/src/app/node_modules
       - bundle:/usr/local/bundle
-    ports:
-      - "3000:3000"
+      - node_modules:/usr/src/app/node_modules
+      - .:/usr/src/app
     tty: true
     stdin_open: true
+services:
   db:
     image: postgres
     volumes:
       - pgdata:/var/lib/postgresql
+  app: 
+    <<: *rails
+    links: 
+      - db
+      - webpacker
+    environment:
+      WEBPACKER_DEV_SERVER_HOST: webpacker
+    ports:
+      - "3000:3000"
+    command: "bash -c 'rm -rf tmp/pid/server.pid && rails s --binding 0.0.0.0'"
+  webpacker:
+    <<: *rails
+    command: "./bin/webpack-dev-server"
   # worker:
   #   <<: *rails
   #   command: bundle exec sidekiq
   #   links:
   #     - redis
-  # webpack:
-  #   <<: *rails
-  #   command: bundle exec bin/webpack-dev-server
   # redis:
   #   image: redis
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "2"
+services:
+  app: &rails
+    build: .
+    environment:
+      PGHOST: "db"
+      PGUSER: "postgres"
+    links:
+      - db
+    env_file: 
+      - .env
+    volumes:
+      - ".:/usr/src/app"
+      - node_modules:/usr/src/app/node_modules
+      - bundle:/usr/local/bundle
+    ports:
+      - "3000:3000"
+    tty: true
+    stdin_open: true
+  db:
+    image: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql
+  # worker:
+  #   <<: *rails
+  #   command: bundle exec sidekiq
+  #   links:
+  #     - redis
+  # webpack:
+  #   <<: *rails
+  #   command: bundle exec bin/webpack-dev-server
+  # redis:
+  #   image: redis
+volumes:
+  pgdata: 
+  bundle:
+  node_modules:

--- a/template.rb
+++ b/template.rb
@@ -22,6 +22,9 @@ def apply_template!
 
   copy_file "Procfile"
   copy_file ".nvmrc"
+  copy_file "Dockerfile"
+  copy_file "docker-compose.yml"
+  copy_file ".dockerignore"
 
   apply "Rakefile.rb"
   apply "config.ru.rb"


### PR DESCRIPTION
Adds Dockerfiles to generated projects.
I've done a bunch of research and tried to build in all the optimisations and best practises so that these dockerfiles can be reused as much as possible between projects (the advantage of encouraging similar Dockerfiles is it allows some layers to be cached).

Best practises:

* Volumes store node modules and bundled gems (this means that the image doesn't need to be rebuilt just because a gem dependency or NPM package is added)
* Image sets up containers to run as a `deploy` user (non-root)
* Always pulls from `ruby:latest` rather than locking to a version (Gemfile and/or .ruby-version _can_ still be used to restrict to a Ruby version)
* `RUN` commands are ordered and structured to encourage Docker to cache layers. 
* We clean up apt once we're done with packages

The docker-compose configuration starts a DB, Rails server, and webpacker container by default. I haven't split webpacker into it's own container before, so I'm not 100% whether this is working correctly, but we can iterate. I have included commented-out examples to run sidekiq w/ redis. 
