### PR TITLE
Resolves Issue #32: Add basic authentication helper method to application controller

### DIFF
--- a/app/controllers/application_controller.rb.tt
+++ b/app/controllers/application_controller.rb.tt
@@ -1,0 +1,15 @@
+class ApplicationController < ActionController::Base
+  before_action :http_basic_auth
+
+  private
+
+  def http_basic_auth
+    return unless ENV['HTTP_BASIC_AUTH_USERNAME'] && \
+                  ENV['HTTP_BASIC_AUTH_PASSWORD']
+
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['HTTP_BASIC_AUTH_USERNAME'] && \
+        password == ENV['HTTP_BASIC_AUTH_PASSWORD']
+    end
+  end
+end

--- a/app/template.rb
+++ b/app/template.rb
@@ -1,8 +1,9 @@
 copy_file "app/assets/stylesheets/application.scss"
 remove_file "app/assets/stylesheets/application.css"
 
+template "app/controllers/application_controller.rb", force: true
 copy_file "app/controllers/home_controller.rb"
-template "app/views/layouts/application.html.erb", :force => true
+template "app/views/layouts/application.html.erb", force: true
 copy_file "app/views/application/_flash.html.erb"
 copy_file "app/views/home/index.html.erb"
 

--- a/example.env.tt
+++ b/example.env.tt
@@ -4,6 +4,11 @@
 # The purpose of this file is to keep secrets out of source control.
 # For more information, see: direnv.net
 
+# The environment variables below can be uncommented to enable HTTP basic
+# authentication
+# HTTP_BASIC_AUTH_USERNAME=example
+# HTTP_BASIC_AUTH_PASSWORD=example
+
 SECRET_KEY_BASE=<%= SecureRandom.hex(64) %>
 REDIS_URL=redis://localhost:6379/<%= rand(16) %>
 SIDEKIQ_WEB_USERNAME=admin


### PR DESCRIPTION
Adds `http_basic_auth` to the generated `ApplicationController`. I felt that using a template was more appropriate here than gsubbing into the file, since we needed to define a private method and a before action hook.

This method is used by several Ackama projects, so is just being formalised here. It uses the presence of environment variables to determine whether to enable HTTP basic authentication for an application or not. This makes it easy to selectively enable auth, e.g. using `heroku config:set`. 