### PR TITLE
Resolve Issue #22: Improve experience with git commands

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -146,7 +146,7 @@ def staging_hostname
 end
 
 def any_local_git_commits?
-  system("git log &> /dev/null")
+  system("git log > /dev/null 2>&1")
 end
 
 

--- a/template.rb
+++ b/template.rb
@@ -66,7 +66,6 @@ def apply_template!
       git commit: "-n -m 'Set up project'"
       if git_repo_specified?
         git remote: "add origin #{git_repo_url.shellescape}"
-        git push: "-u origin --all"
       end
     end
   end

--- a/template.rb
+++ b/template.rb
@@ -2,6 +2,7 @@
 
 require "fileutils"
 require "shellwords"
+require "pp"
 
 RAILS_REQUIREMENT = "~> 6.0.0".freeze
 
@@ -63,7 +64,7 @@ def apply_template!
 
     unless any_local_git_commits?
       git add: "-A ."
-      git commit: "-n -m 'Set up project'"
+      git commit: "-n -m 'Initial commit' -m 'Project generated with options:\n\n#{options.pretty_inspect}'"
       if git_repo_specified?
         git remote: "add origin #{git_repo_url.shellescape}"
       end


### PR DESCRIPTION
A range of improvements to the dev experience with the git parts of Rails app generation:

1. Stop pushing after the app is generated. Let the dev choose when to do that (resolves #22)
2. Fix an issue where a git repo with no commits fails and prevents the initial commit from being written
3. Extend the git commit message to add a pretty-printed hash of the options used to generate the Rails application to the commit message description, for example:

```
commit 64923198f65382faa0ec5be50fe4c2a8a423e81e (HEAD -> master)
Author: Josh McArthur <joshua.mcarthur@gmail.com>
Date:   Wed Dec 11 16:14:07 2019 +1300

    Initial commit
    
    Project generated with options:
    
    {"skip_namespace"=>false,
     "ruby"=>"/home/josh/.asdf/installs/ruby/2.6.3/bin/ruby",
     "database"=>"postgresql",
     "skip_gemfile"=>false,
     "skip_git"=>false,
     "skip_keeps"=>false,
     "skip_action_mailer"=>false,
     "skip_action_mailbox"=>false,
     "skip_action_text"=>false,
     "skip_active_record"=>false,
     "skip_active_storage"=>false,
     "skip_puma"=>false,
     "skip_action_cable"=>false,
     "skip_sprockets"=>false,
     "skip_spring"=>false,
     "skip_listen"=>false,
     "skip_javascript"=>false,
     "skip_turbolinks"=>false,
     "skip_test"=>false,
     "skip_system_test"=>false,
     "skip_bootsnap"=>false,
     "dev"=>false,
     "edge"=>false,
     "no_rc"=>false,
     "api"=>false,
     "skip_bundle"=>false,
     "skip_webpack_install"=>false,
     "template"=>"../../template.rb"}
```

