### PR TITLE
Scheduled Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
+# This file contains the Travis build configuration for the README.
+# Travis is configured to run builds against all branches and pull requests
+# (the result of merging the branch into a local copy of 'master').
+#
+# Travis also supports scheduled builds. These cannot be configured in .travis.yml,
+# but for the purposes of being clear, we **do** have a scheduled build set up to run
+# once per month against 'master' only. This means that we can catch any problems
+# with the template arising from library & framework updates before they affect a new project.
+# 
+# To view the scheduled build configuration, check out: https://travis-ci.org/ackama/rails-template/settings
 language: ruby
 services:
   - postgresql


### PR DESCRIPTION
We've had some discussion of automatically running the rails-template test suite regularly to ensure that any changes in the wider ecosystem do not break our template. Once a month seems like a good balance of catching issues early without over-building, so I have set this up in Travis. They have a neat option to only do a build if there hasn't been one in the preceding 24 hours, so I've also enabled this.

![image](https://user-images.githubusercontent.com/292020/70654920-23e71e80-1cbc-11ea-915f-e2e6742bdc35.png)


We can't schedule builds using .travis.yml, so document the presence of scheduled builds in the Travis YML file