### PR TITLE
Fix rubocop warning

### DIFF
--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -41,7 +41,7 @@ Metrics/ClassLength:
   Exclude:
     - "spec/**/*"
 
-Metrics/LineLength:
+Layout/LineLength:
   Exclude:
     - "config/**/*"
     - "db/**/*"


### PR DESCRIPTION
The warning was:
  .rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout

🤷‍♂ Rubocop changed its mind about where this rule should be categorised I guess