### PR TITLE
Allow log level to be set by LOG_LEVEL env var in production-like envs

### DIFF
--- a/README.md.tt
+++ b/README.md.tt
@@ -151,5 +151,6 @@ above steps and then running the tests successfully, make sure that it is docume
 
 ### Logging
 
-This application uses the `lograge` gem to make Rails create a single log
-line for successful requests in deployed environments.
+* This application uses the `lograge` gem to make Rails create a concise single log line for successful requests in deployed environments. See `config/initializers/lograge.rb` for details.
+* If `LOG_LEVEL` exists in the shell environment then it is used to set the log level. Otherise there is a hard-coded fallback for each environment. See `/config/environments/*.rb` for details.
+

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,4 +33,4 @@ end
 
 gsub_file "config/environments/production.rb",
           "config.log_level = :debug",
-          "config.log_level = :info"
+          'config.log_level = ENV.fetch("LOG_LEVEL", "info").to_sym'


### PR DESCRIPTION
Fixes issue #64 . Codecare finds this very useful when we need to temporarily turn up logging to diagnose an issue.