### PR TITLE
Add security.txt to allow security researchers to contact us

### DIFF
--- a/README.md.tt
+++ b/README.md.tt
@@ -149,6 +149,10 @@ above steps and then running the tests successfully, make sure that it is docume
 
 ## Running in production
 
+### security.txt
+
+* `/.well-known/security.txt` exists with instructions which security researchers can use to contact us if they find an issue in this application.
+
 ### Logging
 
 This application uses the `lograge` gem to make Rails create a single log

--- a/public/template.rb
+++ b/public/template.rb
@@ -1,0 +1,9 @@
+##
+# Allow security researchers to contact us if they find an issue in the
+# application. See https://securitytxt.org/
+create_file "public/.well-known/security.txt" do
+  <<~EO_CONTENT
+    Contact: security@ackama.com
+    Preferred-Languages: en
+  EO_CONTENT
+end


### PR DESCRIPTION
See https://securitytxt.org/ for details. Fixes #63 .