### PR TITLE
Fix bug where bundle-audit was not running properly

### DIFF
--- a/bin/ci-run
+++ b/bin/ci-run
@@ -15,7 +15,7 @@ bundle exec rubocop -D --parallel
 echo "* ******************************************************"
 echo "* Running bundle-audit"
 echo "* ******************************************************"
-bundle exec bundle-audit check --update --ignore $ignore
+bundle exec bundle-audit check --update
 
 echo "* ******************************************************"
 echo "* Running brakeman"


### PR DESCRIPTION
`$ignore` is empty in most cases which was causing bundle-audit to not
run. This application does not have any CVEs that it needs to ignore so
I have removed the flag.
