### PR TITLE
Allow running Rails in production modes locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ set up Rails projects the way Ackama likes them.
 
 This is the application template that we use for Rails 6 projects. As a
 fabulous consultancy, we need to be able to start new projects quickly and
-with a good set of defaults. 
+with a good set of defaults.
 
 For older versions of Rails, use these branches of @mattbrictson's original repository:
 
@@ -19,7 +19,7 @@ For older versions of Rails, use these branches of @mattbrictson's original repo
 - [Rails 5.2.x](https://github.com/mattbrictson/rails-template/tree/rails-52)
 
 ## Requirements
- 
+
 - Yarn: Some old versions of Yarn have encountered issues, if you have problems try v1.21.0 or later
 
 This template currently works with:
@@ -51,7 +51,7 @@ rails new blog \
 _Remember that options must go after the name of the application._ The only
 database supported by this template is `postgresql`.
 
-Here are some additional options you can add to this command. We don't _prescribe_ these, 
+Here are some additional options you can add to this command. We don't _prescribe_ these,
 but you may find that many Ackama projects are started with some or all of these options:
 
 * `--skip-action-mailbox` skips the setup of ActionMailbox, which you don't need unless you are receiving emails in your application.
@@ -62,8 +62,8 @@ but you may find that many Ackama projects are started with some or all of these
   having an open websocket connection without knowing about it.
 * `--skip-turbolinks` - in a similar vein to spring, Turbolinks is great and providing some user feedback as pages load
   and speeding up perceived load time, however comes with drawbacks that usually outweight the benefits.
-* `--webpack=react` - this will preconfigure your app to build and serve React code. You only need it if you're going 
-  to be using React, but adding this during app generation will mean that your codebase supports webpack and React 
+* `--webpack=react` - this will preconfigure your app to build and serve React code. You only need it if you're going
+  to be using React, but adding this during app generation will mean that your codebase supports webpack and React
   components right from the first commit.
 
 If you just want to see what the template does, try running `docker build .` and
@@ -74,8 +74,8 @@ include PostgreSQL right now, so database operations don't work.
 ## Installation (Optional)
 
 If you find yourself generating a lot of Rails applications, you
-can load default options into a file in your home directory named `.railsrc`, and 
-these options will be applied as arguments each time you run `rails new` 
+can load default options into a file in your home directory named `.railsrc`, and
+these options will be applied as arguments each time you run `rails new`
 (unless you pass the `--no-rc` option).
 
 To make this the default Rails application template on your system, create a
@@ -89,7 +89,7 @@ To make this the default Rails application template on your system, create a
 Once you’ve installed this template as your default, then all you have to do is run:
 
 ```
-rails new blog
+rails new --database=postgresql blog
 ```
 
 ## What does it do?
@@ -138,6 +138,6 @@ generator system, allowing all of its ERb templates and files to be referenced
 when the application template script is evaluated.
 
 Rails generators are very lightly documented; what you’ll find is that most of
-the heavy lifting is done by [Thor][]. The most common methods used by this
+the heavy lifting is done by [Thor][http://whatisthor.com/]. The most common methods used by this
 template are Thor’s `copy_file`, `template`, and `gsub_file`. You can dig into
-the well-organized and well-documented [Thor source code][thor] to learn more.
+the well-organized and well-documented [Thor source code][https://github.com/erikhuda/thor] to learn more.

--- a/README.md.tt
+++ b/README.md.tt
@@ -158,3 +158,22 @@ above steps and then running the tests successfully, make sure that it is docume
 * This application uses the `lograge` gem to make Rails create a concise single log line for successful requests in deployed environments. See `config/initializers/lograge.rb` for details.
 * If `LOG_LEVEL` exists in the shell environment then it is used to set the log level. Otherise there is a hard-coded fallback for each environment. See `/config/environments/*.rb` for details.
 
+### Running in staging mode locally
+
+```sh
+# precompile assets
+$ RAILS_ENV=staging RAILS_LOG_TO_STDOUT=true bundle exec rails assets:precompile
+
+# run server (note you need **all** these flags to run staging locally)
+$ RAILS_ENV=staging RAILS_LOG_TO_STDOUT=true RAILS_SERVE_STATIC_FILES=true bundle exec rails server
+```
+
+### Running in production mode locally
+
+```sh
+# precompile assets
+$ RAILS_ENV=production RAILS_LOG_TO_STDOUT=true bundle exec rails assets:precompile
+
+# run server (note you need **all** these flags to run production locally)
+$ RAILS_ENV=production RAILS_LOG_TO_STDOUT=true RAILS_SERVE_STATIC_FILES=true bundle exec rails server
+```

--- a/config/database.example.yml.tt
+++ b/config/database.example.yml.tt
@@ -45,3 +45,17 @@ test:
   database: <%= app_name %>_test
   min_messages: WARNING
   pool: 5
+
+staging:
+  adapter: postgresql
+  encoding: unicode
+  database: <%= app_name %>_staging
+  min_messages: WARNING
+  pool: 5
+
+production:
+  adapter: postgresql
+  encoding: unicode
+  database: <%= app_name %>_production
+  min_messages: WARNING
+  pool: 5


### PR DESCRIPTION
This change allows Rails to be run in staging or production mode locally. This is necessary when debugging asset pre-compilation for production environments.

I have also documented how to actually run rails in prod locally in the generated `README.md` which will hopefully be useful for newer players