### PR TITLE
Start using Webpacker for images and SCSS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,0 @@
-//= require_tree .
-//= require_self

--- a/app/template.rb
+++ b/app/template.rb
@@ -1,14 +1,16 @@
-copy_file "app/assets/stylesheets/application.scss"
-remove_file "app/assets/stylesheets/application.css"
-
+# Configure app/controllers
 copy_file "app/controllers/home_controller.rb"
+
+# Configure app/views
 template "app/views/layouts/application.html.erb", force: true
 copy_file "app/views/application/_flash.html.erb"
 copy_file "app/views/home/index.html.erb"
 
+# Configure app/helpers
 copy_file "app/helpers/retina_image_helper.rb"
 directory "app/middleware"
 
+# Configure empty dirs under app/
 remove_dir "app/jobs"
 empty_directory_with_keep_file "app/workers"
 empty_directory_with_keep_file "app/services"

--- a/app/views/layouts/application.html.erb.tt
+++ b/app/views/layouts/application.html.erb.tt
@@ -15,9 +15,7 @@
     <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> (<%%= l(Rails.application.config.version_time) %>) -->
 
     <%%# CSS should go closest to the top of the document as possible. %>
-    <%%= stylesheet_link_tag("application",
-                            media: "all",
-                            "data-turbolinks-track" => "reload") %>
+    <%%= stylesheet_link_tag("application", media: "all", "data-turbolinks-track": "reload") %>
 
     <%%# JavaScript must be in head for Turbolinks to work. %>
     <%%= javascript_pack_tag "application", "data-turbolinks-track": "reload" %>

--- a/variants/frontend-base/app/frontend/stylesheets/_elements.scss
+++ b/variants/frontend-base/app/frontend/stylesheets/_elements.scss
@@ -1,0 +1,2 @@
+// SCSS for bare HTML elements
+// ***************************

--- a/variants/frontend-base/app/frontend/stylesheets/application.scss
+++ b/variants/frontend-base/app/frontend/stylesheets/application.scss
@@ -1,0 +1,2 @@
+// The entry point for all SCSS
+@import "elements";

--- a/variants/frontend-base/app/template.rb
+++ b/variants/frontend-base/app/template.rb
@@ -1,4 +1,0 @@
-gsub_file "app/views/layouts/application.html.erb",
-          "<%= stylesheet_link_tag(",
-          "<%= stylesheet_pack_tag(",
-          force: true

--- a/variants/frontend-base/config/template.rb
+++ b/variants/frontend-base/config/template.rb
@@ -1,4 +1,0 @@
-gsub_file "config/webpacker.yml", 
-          "source_path: app/javascript", 
-          "source_path: app/frontend", 
-          force: true


### PR DESCRIPTION
This change makes loading images, SCSS and JS via Webpacker the default (encouraged) way to handle assets in the generated Rails app.

As much as I don't want to go messing with a system that works (i.e. handling SCSS and images in the asset pipeline), there are some things we want to do for performance e.g. automatically running `imageoptim` aon images, that will be a lot easier to land in Webpacker so I think we should make the break away from the asset pipeline for new Rails apps.

### Testing this branch

I have created https://github.com/eoinkelly/temp-demo-rails-template-output which contains the Rails app generated by this branch. 

The following describes everything you need to do to test this branch locally:

```bash
cd /tmp
git clone git@github.com:ackama/rails-template.git
cd rails-template
git checkout feature/images-and-scss-in-webpacker 

cd /tmp
# automatically answer the interactive prompts that this template would normally ask in the terminal
echo -e "example.com\nstaging.example.com\nn\nn" | rails new my-test-app --no-rc --database=postgresql --template=/tmp/rails-template/template.rb
```

### Feedback

I'm expecting this PR to prompt some discussion, especially on maximum-sass - anything in here can be changed - the goal is to kick off the discussion.

### Summary of changes
  
* Generate only app/assets/config/manifest.js because the asset pipeline
      requires it
    * Add commented out example of how to reference images to application
      layout.
    * Fix bug where stylesheet_pack_tag was being generated but Webpacker
      was not emitting a CSS file (because none was imported into the pack JS)
    * Demonstrate application.scss loading _elements.scss to encourage devs
      to load all SCSS via @import rather than importing into the pack JS
* Move the following templates into variants/frontend-base/template.rb
  because the logic was easier to follow (IMHO) in one template:
    * variants/frontend-base/app/template.rb
    * variants/frontend-base/config/template.rb