### PR TITLE
Set appropriate caching headers when Rails serves assets in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,14 +41,12 @@ insert_into_file "config/environments/production.rb",
     # | Seconds  | Days     |
     # |----------|----------|
     # | 86400    | 1 day    |
-    # | 15552000 | 180 days |
     # | 31536000 | 365 days |
     #
     # Overview of Cache-control values:
     #
     #     max-age=<seconds>
-    #         The maximum amount of time a resource is considered fresh. Unlike
-    #         Expires, this directive is relative to the time of the request.
+    #         The maximum amount of time a resource is considered fresh.
     #
     #     s-maxage=<seconds>
     #         Overrides max-age or the Expires header, but only for shared
@@ -58,7 +56,8 @@ insert_into_file "config/environments/production.rb",
     #
     # Our Cache-Control header:
     #
-    # * It tells all caches (both proxies like Cloudflare and the users web browser) that the asset can be cached.
+    # * It tells all caches (both proxies like Cloudflare and the users web
+    #   browser) that the asset can be cached.
     # * It tells shared caches (e.g. Cloudflare) that they can cache it for 365 days
     # * It tells browsers that they should cache for 365 days
     #
@@ -66,8 +65,7 @@ insert_into_file "config/environments/production.rb",
     # want Cloudflare to cache differently than then browser.
     #
     config.public_file_server.headers = {
-      "Cache-Control" => "public, s-maxage=31536000, max-age=31536000",
-      "Expires" => "#{1.year.from_now.to_formatted_s(:rfc822)}"
+      "Cache-Control" => "public, s-maxage=31536000, max-age=31536000"
     }
 
   RUBY

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,11 +38,6 @@ insert_into_file "config/environments/production.rb",
     # Ensure that Rails sets appropriate caching headers on static assets if
     # Rails is serving static assets in production e.g. on Heroku
     #
-    # | Seconds  | Days     |
-    # |----------|----------|
-    # | 86400    | 1 day    |
-    # | 31536000 | 365 days |
-    #
     # Overview of Cache-control values:
     #
     #     max-age=<seconds>
@@ -65,7 +60,7 @@ insert_into_file "config/environments/production.rb",
     # want Cloudflare to cache differently than then browser.
     #
     config.public_file_server.headers = {
-      "Cache-Control" => "public, s-maxage=31536000, max-age=31536000"
+      "Cache-Control" => "public, s-maxage=#{365.days.seconds}, max-age=#{365.days.seconds}"
     }
 
   RUBY

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ insert_into_file "config/environments/production.rb",
     #
     # Our Cache-Control header:
     #
-    # * tells all caches (both proxies like Cloudflare and the users web browser) that the asset can be cached.
+    # * It tells all caches (both proxies like Cloudflare and the users web browser) that the asset can be cached.
     # * It tells shared caches (e.g. Cloudflare) that they can cache it for 365 days
     # * It tells browsers that they should cache for 365 days
     #
@@ -72,4 +72,3 @@ insert_into_file "config/environments/production.rb",
 
   RUBY
 end
-

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,3 +30,46 @@ end
 gsub_file "config/environments/production.rb",
           "config.log_level = :debug",
           'config.log_level = ENV.fetch("LOG_LEVEL", "info").to_sym'
+
+insert_into_file "config/environments/production.rb",
+  after: /.*config\.public_file_server\.enabled.*\n/ do
+  <<~'RUBY'
+
+    # Ensure that Rails sets appropriate caching headers on static assets if
+    # Rails is serving static assets in production e.g. on Heroku
+    #
+    # | Seconds  | Days     |
+    # |----------|----------|
+    # | 86400    | 1 day    |
+    # | 15552000 | 180 days |
+    # | 31536000 | 365 days |
+    #
+    # Overview of Cache-control values:
+    #
+    #     max-age=<seconds>
+    #         The maximum amount of time a resource is considered fresh. Unlike
+    #         Expires, this directive is relative to the time of the request.
+    #
+    #     s-maxage=<seconds>
+    #         Overrides max-age or the Expires header, but only for shared
+    #         caches (e.g., proxies). Ignored by private caches.
+    #
+    #     More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    #
+    # Our Cache-Control header:
+    #
+    # * tells all caches (both proxies like Cloudflare and the users web browser) that the asset can be cached.
+    # * It tells shared caches (e.g. Cloudflare) that they can cache it for 365 days
+    # * It tells browsers that they should cache for 365 days
+    #
+    # Cloudflare will respect s-maxage if it is set so change that value if you
+    # want Cloudflare to cache differently than then browser.
+    #
+    config.public_file_server.headers = {
+      "Cache-Control" => "public, s-maxage=31536000, max-age=31536000",
+      "Expires" => "#{1.year.from_now.to_formatted_s(:rfc822)}"
+    }
+
+  RUBY
+end
+


### PR DESCRIPTION
This typically happens on Heroku deployments which do not (yet) use a CDN.

This came up pretty regularly in my Lighthouse experiments so I thought we should fix it. Rails asset precompilation (whether through the old sprockets or newer webpacker methods) adds a unique fingerprint to all asset names e.g. `application.css` becomes something like `application. 2780cef1a5b202b2f5823863ca7d360f79cfa29f238ebc06cde7d3a5e60bac3c.css` - the fingerprint is calculated based on the contents of the file so it will change if the file changes. This allows us to set cache control headers which allow proxies/browser to cache assets for up to 1 year because if the asset does change the URL to it will also change and thereby "bust" the cache.