### PR TITLE
Disable /dev/shm usage in Chrome

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,7 @@ Capybara.register_driver :chrome do |app|
   # Docker compatibility
   options.add_argument("--headless")
   options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
 
   Capybara::Selenium::Driver.new app, browser: :chrome, options: options
 end


### PR DESCRIPTION
/dev/shm is a filesystem device that on Linux systems is guaranteed to be tmpfs - in memory, not written to disk. The same guarantee is not true of `/tmp`, which is where files are typically stored.

Chrome prefers /dev/shm by default for the performance improvement on systems that have a tmp directory that is written to disk, however /dev/shm is limited by the available memory.

Within a Docker container, `/dev/shm` is usually set to 64mb. This is large enough for Chrome to use it, but small enough that it can lead to an out-of-memory type error when Chrome is rendering a large page - e.g. something with a lot of JS, maps, complex UI - that sort of thing.

We disable `/dev/shm` here, as it universally makes Chrome more stable, but has an especially beneficial effect to Chrome running inside containers.