### PR TITLE
Stop overcommit from failing when Rubocop warns about new cops

### DIFF
--- a/overcommit.yml
+++ b/overcommit.yml
@@ -36,7 +36,6 @@ PreCommit:
 
   RuboCop:
     enabled: true
-    on_warn: fail
 
   TrailingWhitespace:
     enabled: true


### PR DESCRIPTION
Rubocop periodically releases new cops. If these cops are not configured
in your .rubocop.yml (or some parent .rubocop.yml) then Rubocop tells
you in its output and this output causes overcommit to fail with a false
positive.