### PR TITLE
Production envs should default to force_ssl being on

### DIFF
--- a/README.md.tt
+++ b/README.md.tt
@@ -162,18 +162,18 @@ above steps and then running the tests successfully, make sure that it is docume
 
 ```sh
 # precompile assets
-$ RAILS_ENV=staging RAILS_LOG_TO_STDOUT=true bundle exec rails assets:precompile
+$ RAILS_FORCE_SSL=false RAILS_ENV=staging RAILS_LOG_TO_STDOUT=true bundle exec rails assets:precompile
 
 # run server (note you need **all** these flags to run staging locally)
-$ RAILS_ENV=staging RAILS_LOG_TO_STDOUT=true RAILS_SERVE_STATIC_FILES=true bundle exec rails server
+$ RAILS_FORCE_SSL=false RAILS_ENV=staging RAILS_LOG_TO_STDOUT=true RAILS_SERVE_STATIC_FILES=true bundle exec rails server
 ```
 
 ### Running in production mode locally
 
 ```sh
 # precompile assets
-$ RAILS_ENV=production RAILS_LOG_TO_STDOUT=true bundle exec rails assets:precompile
+$ RAILS_FORCE_SSL=false RAILS_ENV=production RAILS_LOG_TO_STDOUT=true bundle exec rails assets:precompile
 
 # run server (note you need **all** these flags to run production locally)
-$ RAILS_ENV=production RAILS_LOG_TO_STDOUT=true RAILS_SERVE_STATIC_FILES=true bundle exec rails server
+$ RAILS_FORCE_SSL=false RAILS_ENV=production RAILS_LOG_TO_STDOUT=true RAILS_SERVE_STATIC_FILES=true bundle exec rails server
 ```

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -8,10 +8,19 @@ insert_into_file "config/environments/production.rb",
   RUBY
 end
 
-uncomment_lines "config/environments/production.rb", /config\.force_ssl = true/
 gsub_file "config/environments/production.rb",
-          "config.force_ssl = true",
-          'config.force_ssl = ENV["RAILS_FORCE_SSL"].present?'
+          "# config.force_ssl = true",
+          <<~RUBY
+            ##
+            # `force_ssl` defaults to on. Turn off `force_ssl` if (and only if) RAILS_FORCE_SSL=false.
+            #
+            config.force_ssl = if ENV.fetch("RAILS_FORCE_SSL", "").casecmp("false").zero?
+                                 false
+                               else
+                                 true
+                               end
+          RUBY
+
 
 insert_into_file "config/environments/production.rb",
                  after: /# config\.action_mailer\.raise_deliv.*\n/ do


### PR DESCRIPTION
This change defaults `force_ssl` to being true but allows you to disable
it by setting `RAILS_FORCE_SSL=false` in the env. Running Rails without
forcing SSL is useful when running in production mode locally to debug
asset precompiles etc.