### PR TITLE
Add default config for cache-control on ActiveStorage uploads

### DIFF
--- a/config/template.rb
+++ b/config/template.rb
@@ -48,3 +48,22 @@ route <<-EO_ROUTES
 
   root "home#index"
 EO_ROUTES
+
+gsub_file "config/storage.yml", /#   service: S3/ do
+  <<~YAML
+    #   service: S3
+    #   upload:
+    #     # TEAM DECISION REQUIRED: The correct caching duration for files
+    #     # stored by Active Storage is project dependent so you should discuss
+    #     # this with you team if you don't feel able to make the decision solo.
+    #     #
+    #     # These options are are not well documented in ActiveStorage. They
+    #     # are passed directly to the S3 SDK. Details:
+    #     # https://github.com/rails/rails/blob/master/activestorage/lib/active_storage/service/s3_service.rb
+    #     #
+    #     # * private: the browser should cache but intermediate proxies (e.g. CDNs) should not
+    #     # * max-age: the number of seconds to cache the file for
+    #     #
+    #     cache_control: 'private, max-age=<%= 365.days.seconds %>'
+  YAML
+end


### PR DESCRIPTION
ActiveStorage defaults to not setting a `Cache-Control` header so any files served by it will never be cached by the Browser. I think that in most cases we do want caching on this. Sing out if you disagree.

Below is an example of the `config/storage.yml` that gets created **after** this change.

```yaml
ttest:
  service: Disk
  root: <%= Rails.root.join("tmp/storage") %>

local:
  service: Disk
  root: <%= Rails.root.join("storage") %>

# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
# amazon:
#   service: S3
#   upload:
#     # These options are are not well documented in ActiveStorage. They
#     # are passed directly to the S3 SDK. Details:
#     # https://github.com/rails/rails/blob/master/activestorage/lib/active_storage/service/s3_service.rb
#     #
#     # * private: the browser should cache but intermediate proxies (e.g. CDNs) should not
#     # * max-age: the number of seconds to cache the file for
#     #
#     cache_control: 'private, max-age=<%= 365.days.seconds %>'

#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
#   region: us-east-1
#   bucket: your_own_bucket

# Remember not to checkin your GCS keyfile to a repository
# google:
#   service: GCS
#   project: your_project
#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
#   bucket: your_own_bucket

# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
# microsoft:
#   service: AzureStorage
#   storage_account_name: your_account_name
#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
#   container: your_container_name

# mirror:
#   service: Mirror
#   primary: local
#   mirrors: [ amazon, google, microsoft ]
```