### PR TITLE
Load default email 'From' address from environment variable

### DIFF
--- a/app/template.rb
+++ b/app/template.rb
@@ -14,3 +14,8 @@ directory "app/middleware"
 remove_dir "app/jobs"
 empty_directory_with_keep_file "app/workers"
 empty_directory_with_keep_file "app/services"
+
+# Configure the default mailer to use the our default from address
+gsub_file "app/mailers/application_mailer.rb",
+  "default from: 'from@example.com'",
+  "default from: Rails.application.secrets.mail_from"

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -12,6 +12,10 @@ default: &default
   # You can use `rails secret` to generate a secure secret key.
   secret_key_base: "<%%= ENV['RAILS_SECRET_KEY_BASE'] %>"
 
+  # The default `From:` address to use for email sent by this application
+  # obviously isn't a secret per se, but configuring it here is convenient
+  mail_from: "<%%= ENV['MAIL_FROM'] %>"
+
 development:
   <<: *default
 

--- a/example.env.tt
+++ b/example.env.tt
@@ -9,5 +9,6 @@
 # HTTP_BASIC_AUTH_USERNAME=example
 # HTTP_BASIC_AUTH_PASSWORD=example
 
+MAIL_FROM=changeme@example.com
 SECRET_KEY_BASE=<%= SecureRandom.hex(64) %>
 PORT=3000


### PR DESCRIPTION
This address is uses in a few places in most real apps e.g.

* ActionMailer (as seen in this change)
* Devise
* Transactional email sending services e.g. Mandrill, Sendgrid

so it is useful to have a single place to change it.

@joshmcarthur mentioned in the conversation on PR #57 that this was a default he used on some apps and I think it's useful enough to be a default for all templates. If/when this change lands I can update PR #57 to us the value from secrets.