### PR TITLE
Provision and configure default health checks

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -14,6 +14,7 @@ gem "turbolinks"<%= gemfile_requirement("turbolinks") %>
 <% end -%>
 gem "webpacker"<%= gemfile_requirement("webpacker") %>
 gem "lograge"
+gem "okcomputer"
 
 gem "rack-canonical-host", "~> 0.2.3"
 

--- a/README.md.tt
+++ b/README.md.tt
@@ -61,6 +61,33 @@ All credentials and the `.env` file for this project are stored in Ackama 1Passw
 
     TODO: Ensure that all secrets in this app are stored **only** in Ackama 1Password
 
+## Healthchecks
+
+A healthcheck endpoint is available at http://localhost:3000/healthchecks/all. Healthchecks are 
+configured in `config/initializers/health_checks.rb`. By default, the following health checks are enabled:
+
+* Default (app is running)
+* App version (the git commit that is running)
+* Database connectivity
+
+Extra checks can be enabled or added within this initializer.
+
+The health check endpoint has it's own authentication checks that can be specified:
+
+* `ENV["HEALTHCHECK_HTTP_BASIC_AUTH_USERNAME]`
+* `ENV["HEALTHCHECK_HTTP_BASIC_AUTH_PASSWORD]`
+
+This enables a unique set of credentials to exist for accessing the health checks endpoint.
+
+If either of these settings are unspecified, then the configuration will fall back to the default
+HTTP basic auth settings:
+
+* `ENV["HTTP_BASIC_AUTH_USERNAME]`
+* `ENV["HTTP_BASIC_AUTH_PASSWORD]`
+
+If neither of these credentials are configured, then the healthcheck endpoint will be
+publicly available, which may be what you want, but maybe not.
+
 ## Project Resources:
 
 | **Resource**    | **URL**                           |

--- a/config/initializers/health_checks.rb
+++ b/config/initializers/health_checks.rb
@@ -5,9 +5,13 @@ username = ENV["HEALTHCHECK_HTTP_BASIC_AUTH_USERNAME"] || ENV["HTTP_BASIC_AUTH_U
 password = ENV["HEALTHCHECK_HTTP_BASIC_AUTH_PASSWORD"] || ENV["HTTP_BASIC_AUTH_PASSWORD"]
 OkComputer.require_authentication(username, password) if username && password
 
+# Sets the app version from known Heroku environment variables
+ENV["SHA"] ||= ENV["HEROKU_SLUG_COMMIT"]
+
 # Checks the deployed commit. This is discovered from:
 # A 'REVISION' file that is created during a Capistrano deploy
 # ENV['SHA'] that can be set within e.g. a Docker container
+# ENV['HEROKU_SLUG_COMMIT'] set above
 OkComputer::Registry.register "app_version", OkComputer::AppVersionCheck.new
 
 # Additional checks can be added, e.g.

--- a/config/initializers/health_checks.rb
+++ b/config/initializers/health_checks.rb
@@ -1,10 +1,13 @@
 # okcomputer is used for health checks
+# https://github.com/sportngin/okcomputer/
 
 username = ENV["HEALTHCHECK_HTTP_BASIC_AUTH_USERNAME"] || ENV["HTTP_BASIC_AUTH_USERNAME"]
 password = ENV["HEALTHCHECK_HTTP_BASIC_AUTH_PASSWORD"] || ENV["HTTP_BASIC_AUTH_PASSWORD"]
 OkComputer.require_authentication(username, password) if username && password
 
-# Check that Redis is available
+# Checks the deployed commit. This is discovered from:
+# A 'REVISION' file that is created during a Capistrano deploy
+# ENV['SHA'] that can be set within e.g. a Docker container
 OkComputer::Registry.register "app_version", OkComputer::AppVersionCheck.new
 
 # Additional checks can be added, e.g.
@@ -13,6 +16,14 @@ OkComputer::Registry.register "app_version", OkComputer::AppVersionCheck.new
 # OkComputer::Registry.register "sidekiq_default", OkComputer::SidekiqLatencyCheck.new(:default)
 # OkComputer::Registry.register "sidekiq_mailers", OkComputer::SidekiqLatencyCheck.new(:mailers)
 # => More at https://github.com/sportngin/okcomputer/tree/master/lib/ok_computer/built_in_checks/
+
+# Checks can be made optional. This means that the status of the checks is still reported,
+# but the overall health check status won't be affected.
+# From the checks above, we do not want our overall server health to be determined 
+# based on mailing, redis or sidekiq, but we do want to report on any of these checks 
+# that have failed.
+# OkComputer.make_optional %w(mailing redis sidekiq_default sidekiq_mailers)
+
 
 # Run checks in parallel
 OkComputer.check_in_parallel = true

--- a/config/initializers/health_checks.rb
+++ b/config/initializers/health_checks.rb
@@ -1,0 +1,24 @@
+# okcomputer is used for health checks
+
+username = ENV["HEALTHCHECK_HTTP_BASIC_AUTH_USERNAME"] || ENV["HTTP_BASIC_AUTH_USERNAME"]
+password = ENV["HEALTHCHECK_HTTP_BASIC_AUTH_PASSWORD"] || ENV["HTTP_BASIC_AUTH_PASSWORD"]
+OkComputer.require_authentication(username, password) if username && password
+
+# Check that Redis is available
+OkComputer::Registry.register "app_version", OkComputer::AppVersionCheck.new
+
+# Additional checks can be added, e.g.
+# OkComputer::Registry.register "mailing", OkComputer::ActionMailerCheck.new
+# OkComputer::Registry.register "redis", OkComputer::RedisCheck.new({})
+# OkComputer::Registry.register "sidekiq_default", OkComputer::SidekiqLatencyCheck.new(:default)
+# OkComputer::Registry.register "sidekiq_mailers", OkComputer::SidekiqLatencyCheck.new(:mailers)
+# => More at https://github.com/sportngin/okcomputer/tree/master/lib/ok_computer/built_in_checks/
+
+# Run checks in parallel
+OkComputer.check_in_parallel = true
+
+# Mount at /healthchecks in config/routes.rb
+OkComputer.mount_at = false
+
+# Log when health checks are run
+OkComputer.logger = Rails.logger

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-    # lograge can be customised to add custom values to logs, ignore certain
-    # controllers etc. Full instructions at https://github.com/roidrage/lograge
-    config.lograge.enabled = true unless Rails.env.development? || Rails.env.test?
-  end
+  # lograge can be customised to add custom values to logs, ignore certain
+  # controllers etc. Full instructions at https://github.com/roidrage/lograge
+  config.lograge.enabled = true unless Rails.env.development? || Rails.env.test?
+end

--- a/config/template.rb
+++ b/config/template.rb
@@ -11,6 +11,7 @@ copy_file "config/initializers/generators.rb"
 copy_file "config/initializers/rotate_log.rb"
 copy_file "config/initializers/version.rb"
 copy_file "config/initializers/lograge.rb"
+copy_file "config/initializers/health_checks.rb"
 
 gsub_file "config/initializers/filter_parameter_logging.rb", /\[:password\]/ do
   "%w[password secret session cookie csrf]"
@@ -20,6 +21,10 @@ apply "config/environments/development.rb"
 apply "config/environments/production.rb"
 apply "config/environments/test.rb"
 template "config/environments/staging.rb.tt"
+
+route <<~HEALTH_CHECK_ROUTES
+  mount OkComputer::Engine, at: "/healthchecks"
+HEALTH_CHECK_ROUTES
 
 route <<-EO_ROUTES
   ##

--- a/spec/requests/health_checks_spec.rb
+++ b/spec/requests/health_checks_spec.rb
@@ -1,0 +1,24 @@
+
+require "rails_helper"
+
+
+RSpec.describe "Automated health checks", type: :request do
+
+  before(:all) { get "/healthchecks/all" }
+
+  subject { response.body }
+
+
+  it { is_expected.to include("database: PASSED") }
+
+  it { is_expected.to include("default: PASSED") }
+
+  it { is_expected.to include("mailing: PASSED") }
+
+  it { is_expected.to include("redis: PASSED") }
+
+  it { is_expected.to include("sidekiq_default: PASSED") }
+
+  it { is_expected.to include("sidekiq_mailers: PASSED") }
+
+end

--- a/spec/requests/health_checks_spec.rb
+++ b/spec/requests/health_checks_spec.rb
@@ -4,14 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Automated health checks", type: :request do
   before(:all) { get "/healthchecks/all" }
-
   subject { response.body }
-
   it { is_expected.to include("database: PASSED") }
-
   it { is_expected.to include("default: PASSED") }
-
-  it { is_expected.to include("mailing: PASSED") }
-
-  it { is_expected.to include("redis: PASSED") }
 end

--- a/spec/requests/health_checks_spec.rb
+++ b/spec/requests/health_checks_spec.rb
@@ -1,13 +1,11 @@
+# frozen_string_literal: true
 
 require "rails_helper"
 
-
 RSpec.describe "Automated health checks", type: :request do
-
   before(:all) { get "/healthchecks/all" }
 
   subject { response.body }
-
 
   it { is_expected.to include("database: PASSED") }
 
@@ -16,9 +14,4 @@ RSpec.describe "Automated health checks", type: :request do
   it { is_expected.to include("mailing: PASSED") }
 
   it { is_expected.to include("redis: PASSED") }
-
-  it { is_expected.to include("sidekiq_default: PASSED") }
-
-  it { is_expected.to include("sidekiq_mailers: PASSED") }
-
 end


### PR DESCRIPTION
Sets up health checks using [OkComputer](https://github.com/sportngin/okcomputer), which is a really nice framework for declaring and checking health checks.

The configuration as default:

* Checks that the app is running
* Checks that the database can be connected to
* Checks what version of the app is running (as long as it is a deployed environment, otherwise this check fails)
* Secures the health check with basic auth if credentials are configured
* Logs health check status to the Rails logger (this just makes it easier to get a healthcheck snapshot while tailing the logs)

Additionally, I have left checks that I set up for a client project in place, but commented out:

* Mailing checks that ActionMailer is configured and that SMTP can be connected to with the provided details
* Redis checks that Redis can be connected to and queries basic stats
* Sidekiq checks that queue latency isn't too high (if queue latency is high, this means that jobs are backed up)

There are also more checks available built into OkComputer, or additional checks can be implemented pretty easily.

Healthchecks are available at `/healthchecks/all` for a plaintext summary, or `/healthchecks/all.json` for a machine-parseable JSON format, or `/healthchecks/all.xml` for XML. Individual checks are also available at `/healthchecks/{{check name}}` - e.g. `/healthchecks/database`, `/healthchecks/database.json`, `/healthchecks/database.xml`