### PR TITLE
Rubocop warnings about unrecognised cops in config breaks overcommit

### DIFF
--- a/overcommit.yml
+++ b/overcommit.yml
@@ -36,6 +36,7 @@ PreCommit:
 
   RuboCop:
     enabled: true
+    command: ['bundle', 'exec', 'rubocop', '--disable-pending-cops']
 
   TrailingWhitespace:
     enabled: true


### PR DESCRIPTION
* Rubocop warns if it has cops that you have not configured in the YAML
* Rubocop warns if your YAML config mentions cops it does not recognise
* Overcommit (by default) fails if rubocop outputs any warning that it can't parse

This means that overcommit will fail (due to unrecognised warning output
from rubocop) unless the rules configured in your `.rubocop.yml`
**exactly match** the rules that the specific version of rubocop in the
app knows about.

The problem is that we have a single shared `.rubocop.yml` shared
between many apps on many different versions of rubocop and it's not
feasible to keep rubocop updated to the latest version for all apps -
these updates sometimes require code changes and this work would quickly
overwhelm our support team.

Change how rubocop is invoked in `overcommit.yml` to:

```yml
  RuboCop:
    enabled: true
    command: ['bundle', 'exec', 'rubocop', '--disable-pending-cops']
```

Disabling pending cops will stop rubocop from warning about missing
rules. This means overcommit won't break on an older project with an
older version of rubocop.