### PR TITLE
Add content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,0 +1,133 @@
+# Be sure to restart your server when you modify this file.
+
+# Define an application-wide content security policy
+# For further information see the following documentation
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+
+Rails.application.config.content_security_policy do |policy|
+  # These directives define a quite strict policy by default. You may have to
+  # loosen this policy as you add elements to the app. Some examples of common
+  # additions are shown below.
+  #
+  policy.default_src :self
+  policy.font_src    :self
+  policy.img_src     :self
+  policy.object_src  :none
+  policy.script_src  :self
+  policy.style_src   :self
+
+  # Allow inline-styles
+  # ###################
+  #
+  # * The use of both kind of quotes is required here because the value as it
+  #   appears in the CSP header must be surrounded by single quotes.
+  # * Try to avoid enabling this if you can
+  # * IMPORTANT: you can't just uncomment these lines to make this work - you
+  #   need to merge the example into your existing call to the appropriate
+  #   `*_src` method.
+  #
+  # policy.style_src  :self, "'unsafe-inline'"
+
+  # Use a separate host for assets e.g. CDN
+  # #######################################
+  #
+  # * This example adds the external host to the `default_src` policy meaning
+  #   that any kind of asset can be loaded from it. You should be more
+  #   targetted if you can e.g. if the external host is only going to serve
+  #   images then use `policy.img_src` instead.
+  # * IMPORTANT: you can't just uncomment these lines to make this work - you
+  #   need to merge the example into your existing call to the appropriate
+  #   `*_src` method.
+  #
+  # asset_host = if Rails.env.development? || Rails.env.test?
+  #                "http://#{Rails.application.secrets.asset_host}"
+  #              else
+  #                "https://#{Rails.application.secrets.asset_host}"
+  #              end
+  # policy.default_src :self, asset_host
+
+  # Use an S3 bucket for assets
+  # ###########################
+  #
+  # * This example adds the S3 bucket to the `default_src` policy meaning that
+  #   any kind of asset can be loaded from it. You should be more targetted if
+  #   you can e.g. if the bucket is only going to serve images then use
+  #   `policy.img_src` instead.
+  # * IMPORTANT: you can't just uncomment these lines to make this work - you
+  #   need to merge the example into your existing call to the appropriate
+  #   `*_src` method.
+  #
+  # s3_bucket_url = "https://my-app-assets-#{Rails.env.dasherize}.s3.amazonaws.com"
+  # policy.default_src :self, s3_bucket_url
+
+  # Use Google fonts
+  # ################
+  #
+  # * Instructions: https://content-security-policy.com/examples/google-fonts/
+  # * IMPORTANT: you can't just uncomment these lines to make this work - you
+  #   need to merge the example into your existing call to the appropriate
+  #   `*_src` method.
+  #
+  # policy.font_src :self, "https://fonts.gstatic.com"
+  # policy.style_src :self, "https://fonts.googleapis.com"
+
+  # Use Google Tag Manager or Google Analytics
+  # ##########################################
+  #
+  # * Instructions: https://developers.google.com/tag-manager/web/csp
+  # * You can use the nonce version. Rails generates the nonce which you can use as follows:
+  #
+  #     <%= javascript_tag nonce: true do -%>
+  #         <!-- Google tag manager or analytics snippet goes here
+  #     <% end -%>
+  #
+  # https://api.rubyonrails.org/classes/ActionView/Helpers/JavaScriptHelper.html#method-i-javascript_tag
+  # for details.
+
+  # Allow webpack-dev-server to use websockets in development
+  # #########################################################
+  #
+  # * We want to minimize differences in the CSP header between environments so
+  #   that we can find and fix CSP issues in development but enabling the
+  #   webpack-dev-server to communicate over websockets is an exception.
+  #
+  policy.connect_src :self, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+
+  # Enable CSP reporting
+  # ####################
+  #
+  # You should enable a reporting URL so you can find and fix any issues your
+  # users encounter caused by CSP in production.
+  #
+  # If you app is using https://sentry.io then you can use the URL they provide
+  # for your app to report CSP issues - see
+  # https://docs.sentry.io/error-reporting/security-policy-reporting/ for
+  # details
+  #
+  # policy.report_uri "https://o250825.ingest.sentry.io/api/1409600/security/?sentry_key=SOMETHING"
+end
+
+# ###############
+# Configure nonce
+# ###############
+
+# If you are using UJS then enable automatic nonce generation
+Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+
+# Set the nonce only to specific directives
+# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+
+# ################################
+# Configure reporting vs enforcing
+# ################################
+#
+# Report CSP violations to a specified URI. For further information see the
+# following documentation:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+#
+# We default to turning on enforcement in all environments so that we can catch
+# issues early in development before they hit staging or production.
+#
+Rails.application.config.content_security_policy_report_only = false
+
+

--- a/config/template.rb
+++ b/config/template.rb
@@ -11,6 +11,7 @@ copy_file "config/initializers/generators.rb"
 copy_file "config/initializers/rotate_log.rb"
 copy_file "config/initializers/version.rb"
 copy_file "config/initializers/lograge.rb"
+copy_file "config/initializers/content_security_policy.rb", force: true
 copy_file "config/initializers/health_checks.rb"
 
 gsub_file "config/initializers/filter_parameter_logging.rb", /\[:password\]/ do

--- a/spec/requests/content_security_policy_header_spec.rb
+++ b/spec/requests/content_security_policy_header_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Content-Security-Policy HTTP Header", type: :request do
+  context "when the application receives a request" do
+    before do
+      get root_path
+    end
+
+    it "returns a Content-Security-Policy header as part of the response" do
+      expect(response.headers["Content-Security-Policy"]).not_to eq(nil)
+    end
+  end
+end

--- a/variants/devise/template.rb
+++ b/variants/devise/template.rb
@@ -73,15 +73,9 @@ EO_ROUTES
 print_header "Adding example devise links to the homepage"
 gsub_file "app/views/layouts/application.html.erb",
   "<body>",
-  <<~ERB
+  <<~'ERB'
     <body>
-
-    <%
-    # This block uses the "style" attribute to make it easy for you to
-    # delete. This isn't a suggestion that inline styles are a good idea
-    # mmmkay.
-    %>
-    <nav style="border: 1px solid #666; padding: 1em;">
+    <nav>
     <h1>Example devise nav</h1>
     <ul>
       <li>
@@ -90,7 +84,7 @@ gsub_file "app/views/layouts/application.html.erb",
     </ul>
     <% if current_user %>
       <p>
-      You are <span style="color: green">Signed in</span>
+      You are <strong>Signed in</strong>
       </p>
       <ul>
         <li>
@@ -99,7 +93,7 @@ gsub_file "app/views/layouts/application.html.erb",
       </ul>
     <% else %>
       <p>
-      You are <span style="color: darkred">Not signed in</span>
+      You are <strong>Not signed in</strong>
       </p>
       <ul>
         <li>

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -16,7 +16,17 @@ remove_dir "app/assets/images"
 # Configure app/frontend
 
 run "mv app/javascript app/frontend"
+
 gsub_file "config/webpacker.yml", "source_path: app/javascript", "source_path: app/frontend", force: true
+
+# We want webpacker to generate a separate CSS file in all environments because
+#
+# 1. It makes things look more "normal" in browser dev tools
+# 2. We don't have to add 'unsafe-inline' to the CSP header to allow Webpack to
+#    create inline stylesheets
+#
+gsub_file "config/webpacker.yml", "  extract_css: false", "  extract_css: true", force: true
+
 empty_directory_with_keep_file "app/frontend/images"
 copy_file "app/frontend/stylesheets/application.scss"
 copy_file "app/frontend/stylesheets/_elements.scss"


### PR DESCRIPTION
Fixes #90 

The default policy is very strict but the initializer includes some examples of how to loosen it for common scenarios e.g. google fonts, google analytics. Feedback welcome.

* I removed the inline styles from the temporary devise UI we create because they don't provide enough value to enable inline styles in the CSP.
* Webpacker is now creating a separate CSS file in development. This stops it trying to dynamically create `<style>` blocks in the DOM so we don't have to allow that in CSP either.