### PR TITLE
fix: ensure `check_yarn_integrity` is always `false`

### DIFF
--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -19,6 +19,13 @@ run "mv app/javascript app/frontend"
 
 gsub_file "config/webpacker.yml", "source_path: app/javascript", "source_path: app/frontend", force: true
 
+# Yarn's integrity check command is quite buggy, to the point that yarn v2 removed it
+#
+# The integrity check option itself has been removed in webpacker v5.1 but we
+# currently pull in v4, so we just set it to false to be safe
+#
+gsub_file "config/webpacker.yml", "check_yarn_integrity: true", "check_yarn_integrity: false", force: true
+
 # We want webpacker to generate a separate CSS file in all environments because
 #
 # 1. It makes things look more "normal" in browser dev tools


### PR DESCRIPTION
This is failing just the devise template in #105.

The option itself has been [removed](https://github.com/rails/webpacker/pull/2518) in webpacker v5.1.