### PR TITLE
#116: Bundler.with_clean_env was deprecated because the use pattern it was typically being used for wasn't quite right.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -57,7 +57,7 @@ end
 
 def with_clean_bundler_env(&block)
   return block.call unless defined?(Bundler)
-  Bundler.with_clean_env(&block)
+  Bundler.with_original_env(&block)
 end
 
 def copy(example_path)


### PR DESCRIPTION
Instead, Bundler.with_original_env was introduced. This doesn't clean
the environment of bundler entirely, but resets the bundler environment
to the state before the current process was started.

There's however some specific cases where the good old Bundler.clean_env behavior can be useful.
For example, when testing Rails generators, you really want an environment where bundler is out of the picture.

For these situations, Bundler.with_unbundled_env was introduced.

I believe for our use case, bin/setup commands, with_original_env is
what we are after.

In other words:

`Bundler.with_original_env` = reset to how things were before you ran this command
`Bundler.with_unbundled_env` = temporarily forget that bundler is there.

Closes #116