### PR TITLE
Closes Issue #119: Add SMTP configuration to production. This is inherited by staging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,6 +33,17 @@ insert_into_file "config/environments/production.rb",
     protocol: "https"
   }
   config.action_mailer.asset_host = "https://#{production_hostname}"
+
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_HOSTNAME"),
+    port: ENV.fetch("SMTP_PORT"), 
+    enable_starttls_auto: true,
+    user_name: ENV.fetch("SMTP_USERNAME"),
+    password: ENV.fetch("SMTP_PASSWORD"),
+    authentication: "login",
+    domain: production_hostname
+  }
+
   RUBY
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ insert_into_file "config/environments/production.rb",
 
   config.action_mailer.smtp_settings = {
     address: ENV.fetch("SMTP_HOSTNAME"),
-    port: ENV.fetch("SMTP_PORT"), 
+    port: ENV.fetch("SMTP_PORT", 587), 
     enable_starttls_auto: true,
     user_name: ENV.fetch("SMTP_USERNAME"),
     password: ENV.fetch("SMTP_PASSWORD"),

--- a/config/environments/staging.rb.tt
+++ b/config/environments/staging.rb.tt
@@ -10,4 +10,5 @@ Rails.application.configure do
     :protocol => "https"
   }
   config.action_mailer.asset_host = "https://<%= staging_hostname %>"
+  config.action_mailer.smtp_settings[:domain] = staging_hostname
 end

--- a/example.env.tt
+++ b/example.env.tt
@@ -9,6 +9,14 @@
 # HTTP_BASIC_AUTH_USERNAME=example
 # HTTP_BASIC_AUTH_PASSWORD=example
 
+# The environment variables below need to be provided in staging/production environments
+# with outgoing mail. SMTP_PORT defaults to 587 so only needs to be provided if a different
+# port is in use.
+# SMTP_USERNAME=example
+# SMTP_PASSWORD=example
+# SMTP_HOSTNAME=example
+
+
 MAIL_FROM=changeme@example.com
 RAILS_SECRET_KEY_BASE=<%= SecureRandom.hex(64) %>
 PORT=3000


### PR DESCRIPTION
This PR adds SMTP configuration to generated apps, so it's ready to go.
Environment variables allow adjustment of the common SMTP params (username, password, host, port), while the domain uses the production or staging hostname used everywhere else throughout the app.

Closes #119
