### PR TITLE
fix rubocop errors in puma.rb

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,15 +4,15 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
 threads min_threads_count, max_threads_count
 
 port ENV.fetch("PORT", 3000)
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
@@ -20,7 +20,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers_count = ENV.fetch("WEB_CONCURRENCY") { 1 }.to_i
+workers_count = ENV.fetch("WEB_CONCURRENCY", 1 ).to_i
 
 if workers_count > 1
   workers workers_count


### PR DESCRIPTION
Fix for #138 

Sorts out the rubocop errors in `puma.rb` that are currently blocking a bunch of PRs from getting merged.