### PR TITLE
Feature/#79 defer application js pack loading

### DIFF
--- a/app/views/layouts/application.html.erb.tt
+++ b/app/views/layouts/application.html.erb.tt
@@ -18,7 +18,7 @@
     <%%= stylesheet_link_tag("application", media: "all", "data-turbolinks-track": "reload") %>
 
     <%%# JavaScript must be in head for Turbolinks to work. %>
-    <%%= javascript_pack_tag "application", "data-turbolinks-track": "reload" %>
+    <%%= javascript_pack_tag "application", "data-turbolinks-track": "reload", defer: true %>
 
     <%%= yield(:head) %>
 

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -118,6 +118,21 @@ append_to_file "app/frontend/packs/application.js" do
   EO_JS
 end
 
+prepend_to_file "app/frontend/packs/application.js" do
+  <<~'EO_JS'
+    // The application.js pack is defered by default which means that nothing imported 
+    // in this file will begin executing until after the page has loaded. This helps to 
+    // speed up page loading times, especially in apps that have large amounts of js.
+    //  
+    // If you have javascript that *must* execute before the page has finished loading, 
+    // create a separate 'boot.js' pack in the frontend/packs directory and import any 
+    // required files in that. Also remember to add a separate pack_tag entry with:
+    // <%= javascript_pack_tag "boot", "data-turbolinks-track": "reload" %> 
+    // to the views/layouts/application.html.erb file above the existing application pack tag.
+    // 
+  EO_JS
+end
+
 gsub_file "config/initializers/content_security_policy.rb",
   /# policy.report_uri ".+"/,
   'policy.report_uri ENV.fetch("SENTRY_CSP_HEADER_REPORT_ENDPOINT")'


### PR DESCRIPTION
First pass at resolving #79 

Changes the default loading behaviour of the application js pack to defered, and prepends a comment to the top of the file explaining this as well as how to add a new pack.

Comments/alternative executions/things I've missed welcome.
