### PR TITLE
Made CSP reporting url use an environment variable

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -104,7 +104,7 @@ Rails.application.config.content_security_policy do |policy|
   # https://docs.sentry.io/error-reporting/security-policy-reporting/ for
   # details
   #
-  # policy.report_uri "https://o250825.ingest.sentry.io/api/1409600/security/?sentry_key=SOMETHING"
+  policy.report_uri ENV["SENTRY_CSP_HEADER_REPORT_ENDPOINT"]
 end
 
 # ###############

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -104,7 +104,7 @@ Rails.application.config.content_security_policy do |policy|
   # https://docs.sentry.io/error-reporting/security-policy-reporting/ for
   # details
   #
-  policy.report_uri ENV["SENTRY_CSP_HEADER_REPORT_ENDPOINT"]
+  # policy.report_uri "https://o250825.ingest.sentry.io/api/1409600/security/?sentry_key=SOMETHING"
 end
 
 # ###############

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -120,7 +120,7 @@ end
 
 gsub_file "config/initializers/content_security_policy.rb",
   /# policy.report_uri ".+"/,
-  'policy.report_uri ENV.fetch("SENTRY_CSP_HEADER_REPORT_ENDPOINT")'
+  'policy.report_uri ENV["SENTRY_CSP_HEADER_REPORT_ENDPOINT"]'
 
 # Javascript code linting and formatting
 # ######################################


### PR DESCRIPTION
This pr contains a fix for an issue in the template where violations of CSP would result in attempts to report the violation in environments such as development and test where reporting isn't configured. [This fix is the one suggested in the comments in the issue where the reporting url is moved to an environment variable.](https://github.com/ackama/rails-template/issues/124)