### PR TITLE
Run 'yarn audit' as part of generated CI script

### DIFF
--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -86,3 +86,12 @@ append_to_file "bin/ci-run" do
   yarn run scss-lint
   SASSLINT
 end
+
+append_to_file "bin/ci-run" do
+  <<~AUDIT
+  echo "* ******************************************************"
+  echo "* Running JS package audit"
+  echo "* ******************************************************"
+  yarn audit
+  AUDIT
+end


### PR DESCRIPTION
The CI script already audits Ruby packages with `bundle-audit`. It
should also audit JS packages.

Fixes #168 