### PR TITLE
Make dotenv-webpack available on servers

### DIFF
--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -78,7 +78,7 @@ gsub_file "app/views/layouts/application.html.erb", "<body>", body_open_tag_with
 # ############
 
 run "yarn add @sentry/browser"
-run "yarn add dotenv-webpack -D"
+run "yarn add dotenv-webpack"
 
 gsub_file "config/webpack/environment.js",
   "module.exports = environment",


### PR DESCRIPTION
Servers often do not install JS packages from `devDependencies`.
`dotenv-webpack` is required to run `rake assets:precompile` so needs to
be available on servers.

Fixes #115 