### PR TITLE
fix: support rails 6.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,7 @@ gsub_file "config/application.rb",
           "# config.time_zone = 'Central Time (US & Canada)'",
           "config.time_zone = 'Wellington'"
 
-insert_into_file "config/application.rb", after: /^require 'rails\/all'/ do
+insert_into_file "config/application.rb", after: /^require ['"]rails\/all['"]/ do
   # the empty line at the beginning of this string is required
   <<-'RUBY'
 

--- a/template.rb
+++ b/template.rb
@@ -4,7 +4,7 @@ require "fileutils"
 require "shellwords"
 require "pp"
 
-RAILS_REQUIREMENT = "~> 6.0.0".freeze
+RAILS_REQUIREMENT = "~> 6.1.0".freeze
 
 def apply_template!
   assert_minimum_rails_version

--- a/variants/frontend-base/sentry/template.rb
+++ b/variants/frontend-base/sentry/template.rb
@@ -14,6 +14,10 @@ gsub_file "config/webpack/environment.js",
     module.exports = environment;
 EO_JS
 
+insert_into_file "app/frontend/packs/application.js",
+                 "import * as Sentry from '@sentry/browser';\n",
+                 after: /import Rails from "@rails\/ujs"\n/
+
 append_to_file "app/frontend/packs/application.js" do
   <<~'EO_JS'
 
@@ -23,7 +27,6 @@ append_to_file "app/frontend/packs/application.js" do
     // to be initialized **before** we import any of our actual JS so that Sentry
     // can report errors from it.
     //
-    import * as Sentry from '@sentry/browser';
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
       environment: process.env.SENTRY_ENV || process.env.RAILS_ENV

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -22,6 +22,21 @@ gsub_file "app/frontend/packs/application.js",
 gsub_file "app/frontend/packs/server_rendering.js",
           "ReactRailsUJS.useContext(componentRequireContext);", react_rails_replacement
 
+gsub_file(
+  "app/frontend/packs/application.js",
+  'var ReactRailsUJS = require("react_ujs")',
+  "import ReactRailsUJS from 'react_ujs';"
+)
+
+gsub_file(
+  "app/frontend/packs/server_rendering.js",
+  'var ReactRailsUJS = require("react_ujs")',
+  "import ReactRailsUJS from 'react_ujs';"
+)
+
+# var ReactRailsUJS = require('react_ujs');
+# import ReactRailsUJS from 'react_ujs';
+
 javascript_pack_tag_replacement = <<-ERB
     <%= javascript_pack_tag "application", "data-turbolinks-track": "reload", defer: true %>
     <%= javascript_pack_tag "application" %>


### PR DESCRIPTION
[Rails 6.1 changed their requires in templates to use double quotes](https://github.com/rails/rails/pull/38841), so now the generator fails because it can't find `require 'rails/all'`, leading to the require for `http_basic_auth` to be not be added.