### PR TITLE
feat: create typescript variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
           - name: basic
             generator_input: example.com\nstaging.example.com\nNo\nNo\nNo\n\nNo\n
           - name: react
-            generator_input: example.com\nstaging.example.com\nYes\nNo\nNo\n\nNo\n
+            generator_input: example.com\nstaging.example.com\nYes\nNo\nNo\nNo\n\nNo\n
+          - name: react-typescript
+            generator_input: example.com\nstaging.example.com\nYes\nYes\n\No\nNo\n\nNo\n
           - name: foundation
             generator_input: example.com\nstaging.example.com\nNo\nYes\nNo\n\nNo\n
           - name: foundation-layout

--- a/template.rb
+++ b/template.rb
@@ -52,9 +52,14 @@ def apply_template!
     run_with_clean_bundler_env "bin/setup"
 
     apply "variants/frontend-base/template.rb"
-    apply "variants/frontend-react/template.rb" if apply_variant?(:react)
+
+    apply_react = apply_variant?(:react)
+
+    apply "variants/frontend-react/template.rb" if apply_react
     apply "variants/frontend-base/sentry/template.rb"
     apply "variants/frontend-base/js-lint/template.rb"
+
+    apply "variants/frontend-typescript/template.rb" if apply_react & apply_variant?(:typescript)
 
     create_initial_migration
 

--- a/variants/frontend-typescript/.eslintrc.js
+++ b/variants/frontend-typescript/.eslintrc.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    ecmaVersion: 2019,
+    sourceType: 'module'
+  },
+  env: { commonjs: true, node: true, browser: true },
+  extends: ['ackama', 'ackama/@typescript-eslint', 'ackama/react'],
+  ignorePatterns: ['tmp/'],
+  overrides: [
+    {
+      files: [
+        'config/webpack/*',
+        'postcss.config.js',
+        'babel.config.js',
+        '.eslintrc.js'
+      ],
+      parserOptions: { sourceType: 'script' },
+      rules: {
+        '@typescript-eslint/prefer-nullish-coalescing': 'off',
+        '@typescript-eslint/no-require-imports': 'off',
+        '@typescript-eslint/no-var-requires': 'off'
+      }
+    }
+  ],
+  rules: {}
+};
+
+module.exports = config;

--- a/variants/frontend-typescript/app/frontend/components/home/index.tsx
+++ b/variants/frontend-typescript/app/frontend/components/home/index.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback, useState } from 'react';
+import { Form, TextInput } from '../utils';
+
+type FormProps = React.ComponentProps<typeof Form>;
+type FormOnSubmitHandler = Required<FormProps>['onSubmit'];
+type FormOnResetHandler = Required<FormProps>['onReset'];
+
+/**
+ * Builds a full name out of the given parts of a name
+ *
+ * @param {string} firstName
+ * @param {string} middleName
+ * @param {string} lastName
+ *
+ * @return {string}
+ */
+const buildFullName = (
+  firstName: string,
+  middleName: string,
+  lastName: string
+) => {
+  // trim to avoid a double space if middleName is empty
+  const leftOfLastName = `${firstName} ${middleName}`.trim();
+
+  return `${leftOfLastName} ${lastName}`;
+};
+
+const Index: React.VFC = () => {
+  const [firstName, setFirstName] = useState('');
+  const [middleName, setMiddleName] = useState('');
+  const [lastName, setLastName] = useState('');
+
+  const handleSubmit = useCallback<FormOnSubmitHandler>(
+    event => {
+      event.preventDefault();
+
+      const fullName = buildFullName(firstName, middleName, lastName);
+
+      alert(`Hello ${fullName}!`);
+    },
+    [firstName, middleName, lastName]
+  );
+
+  const handleReset = useCallback<FormOnResetHandler>(() => {
+    setFirstName('');
+    setMiddleName('');
+    setLastName('');
+  }, [setFirstName, setMiddleName, setLastName]);
+
+  return (
+    <Form onSubmit={handleSubmit} onReset={handleReset}>
+      <TextInput
+        id="first-name"
+        label="First Name"
+        value={firstName}
+        required
+        onChange={setFirstName}
+      />
+      <br />
+      <TextInput
+        id="middle-name"
+        label="Middle Name"
+        value={middleName}
+        required={false}
+        onChange={setMiddleName}
+      />
+      <br />
+      <TextInput
+        id="last-name"
+        label="Last Name"
+        value={lastName}
+        required
+        onChange={setLastName}
+      />
+    </Form>
+  );
+};
+
+export default Index;

--- a/variants/frontend-typescript/app/frontend/components/utils/Form.tsx
+++ b/variants/frontend-typescript/app/frontend/components/utils/Form.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface Props {
+  submitText?: string;
+
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  onReset?: () => void;
+}
+
+export const Form: React.FC<Props> = props => (
+  <form onSubmit={props.onSubmit} onReset={props.onReset}>
+    {props.children}
+    <br />
+    <input type="submit" value={props.submitText ?? 'Submit'} />
+    {props.onReset && <input type="reset" value="Reset" />}
+  </form>
+);

--- a/variants/frontend-typescript/app/frontend/components/utils/TextInput.tsx
+++ b/variants/frontend-typescript/app/frontend/components/utils/TextInput.tsx
@@ -1,0 +1,31 @@
+import React, { useCallback } from 'react';
+
+interface Props {
+  id: string;
+  label: string;
+  value: string;
+  required?: boolean;
+
+  onChange: (value: string) => void;
+}
+
+export const TextInput: React.FC<Props> = props => {
+  const { onChange } = props;
+  const handleChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+    event => onChange(event.target.value),
+    [onChange]
+  );
+
+  return (
+    <label htmlFor={props.id}>
+      {props.label}:
+      <input
+        id={props.id}
+        type="text"
+        value={props.value}
+        required={props.required}
+        onChange={handleChange}
+      />
+    </label>
+  );
+};

--- a/variants/frontend-typescript/app/frontend/components/utils/index.ts
+++ b/variants/frontend-typescript/app/frontend/components/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './Form';
+export * from './TextInput';

--- a/variants/frontend-typescript/template.rb
+++ b/variants/frontend-typescript/template.rb
@@ -1,0 +1,99 @@
+source_paths.unshift(File.dirname(__FILE__))
+
+run "rails webpacker:install:typescript"
+remove_file "app/frontend/packs/hello_typescript.ts"
+
+types_packages = %w[
+  rails__activestorage
+  rails__ujs
+  actioncable
+  turbolinks
+  dotenv-webpack
+  postcss-import
+  postcss-flexbugs-fixes
+  postcss-preset-env
+  webpack-env
+  eslint
+  babel__core
+].map { |name| "@types/#{name}" }
+
+run "yarn remove prop-types"
+run "yarn add #{types_packages.join " "}"
+run "yarn add -D @typescript-eslint/parser @typescript-eslint/eslint-plugin"
+run "yarn install"
+
+%w[
+  app/frontend/channels/consumer
+  app/frontend/channels/index
+  app/frontend/packs/application
+  app/frontend/packs/server_rendering
+].each do |file|
+  copy_file "#{destination_root}/#{file}.js", "#{file}.ts"
+  remove_file "#{file}.js"
+end
+
+copy_file "tsconfig.json", force: true
+copy_file ".eslintrc.js", force: true
+copy_file "types.d.ts", force: true
+
+gsub_file "app/frontend/channels/index.ts", '_channel\.js', '_channel\.ts'
+gsub_file(
+  "app/frontend/packs/application.ts",
+  "process.env.SENTRY_ENV || process.env.RAILS_ENV",
+  "process.env.SENTRY_ENV ?? process.env.RAILS_ENV"
+)
+
+babel_config_file = "babel.config.js"
+
+insert_into_file babel_config_file, after: /^'use strict';\n/ do
+  <<-JS
+
+/**
+ * Guards that `value` is not `false`
+ *
+ * @param {T | false} value
+ *
+ * @return {value is T}
+ *
+ * @template T
+ */
+const notFalseGuard = value => value !== false;
+
+/** @type {import('@babel/core').ConfigFunction} */
+  JS
+end
+
+gsub_file babel_config_file, "\nmodule.exports = api => {", "const config = api => {"
+gsub_file babel_config_file, "].filter(Boolean)", "].filter(notFalseGuard)"
+append_to_file babel_config_file, "\nmodule.exports = config;"
+
+package_json = JSON.parse(File.read("./package.json"))
+package_json["scripts"]["typecheck"] = "tsc -p . --noEmit"
+File.write("./package.json", JSON.generate(package_json))
+
+# example files
+remove_file "app/frontend/components/HelloWorld.jsx", force: true
+copy_file "app/frontend/components/home/index.tsx", force: true
+copy_file "app/frontend/components/utils/index.ts", force: true
+copy_file "app/frontend/components/utils/Form.tsx", force: true
+copy_file "app/frontend/components/utils/TextInput.tsx", force: true
+gsub_file(
+  "app/views/home/index.html.erb",
+  'react_component("HelloWorld", { greeting: "Hello from react-rails." })',
+  'react_component("home/index")'
+)
+
+# we need to re-run these to apply the ts rules
+run "yarn run js-lint-fix"
+run "yarn run format-fix"
+run "yarn run typecheck"
+
+append_to_file "bin/ci-run" do
+  <<~TYPECHECK
+
+    echo "* ******************************************************"
+    echo "* Running Typechecking"
+    echo "* ******************************************************"
+    yarn run typecheck
+  TYPECHECK
+end

--- a/variants/frontend-typescript/tsconfig.json
+++ b/variants/frontend-typescript/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ES6",
+    "moduleResolution": "Node",
+    "lib": ["ES6", "ES2020","DOM"],
+    "jsx": "react",
+    "noEmit": true,
+    "noEmitOnError": true,
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "useDefineForClassFields": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "exclude": [
+    "coverage",
+    "node_modules",
+    "vendor",
+    "public"
+  ],
+  "files": [".eslintrc.js"],
+  "include": ["**/*.js", "**/*.ts", "**/*.tsx"]
+}

--- a/variants/frontend-typescript/types.d.ts
+++ b/variants/frontend-typescript/types.d.ts
@@ -1,0 +1,50 @@
+/* eslint-disable import/order */
+
+declare module '@rails/webpacker' {
+  import { Configuration, WebpackPluginInstance } from 'webpack';
+
+  interface Plugins {
+    prepend(name: string, plugin: WebpackPluginInstance): void;
+  }
+
+  interface Environment {
+    plugins: Plugins;
+
+    toWebpackConfig(): Configuration;
+  }
+
+  export const environment: Environment;
+}
+
+declare module 'react_ujs' {
+  import RequireContext = __WebpackModuleApi.RequireContext;
+
+  interface ReactRailsUJS {
+    useContext(context: RequireContext): void;
+  }
+
+  const ReactRailsUJS: ReactRailsUJS;
+
+  export default ReactRailsUJS;
+}
+
+declare module '@rails/actioncable' {
+  import ActionCable from 'actioncable';
+
+  export = ActionCable;
+}
+
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.png' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.jpg' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
Closes #186 

I've made this as technically a `react-typescript` variant, as I need to checkout the setup for foundation to see if it's compatible or if I'd have to setup a pipeline.

Included in this is a small couple of components that I've included for three main reasons:

1. Showing off a possible good way to structure the components (based on structure used for a certain boat related app which I thought was very nice- effectively `components` sets out to mirror `views`), 
2. To provide some examples of how to type React/JSX components,
3. Showing off a couple of the basics of React for things like `useState`, `useCallback`, `props.children`, and conditionally rendering components.

-----

I actually expect CI to fail on this initially - when running locally it would throw an error about the nullish coalescing operator despite that being 100% supported; it only seems to fail when whatever is doing the compiling in the script does the compiling but I can't find out what that actually is.

We'll see what happens 🤷‍♂️ 
