### PR TITLE
fix(typescript): use `@types/rails__actiontable`

### DIFF
--- a/variants/frontend-typescript/template.rb
+++ b/variants/frontend-typescript/template.rb
@@ -4,6 +4,7 @@ run "rails webpacker:install:typescript"
 remove_file "app/frontend/packs/hello_typescript.ts"
 
 types_packages = %w[
+  rails__actioncable
   rails__activestorage
   rails__ujs
   actioncable

--- a/variants/frontend-typescript/types.d.ts
+++ b/variants/frontend-typescript/types.d.ts
@@ -28,12 +28,6 @@ declare module 'react_ujs' {
   export default ReactRailsUJS;
 }
 
-declare module '@rails/actioncable' {
-  import ActionCable from 'actioncable';
-
-  export = ActionCable;
-}
-
 declare module '*.svg' {
   const content: string;
   export default content;


### PR DESCRIPTION
By chance someone added [types to DefinitelyTyped for `@rails/actioncable`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51582), meaning we can remove ours 🎉 