### PR TITLE
fix: pin `dotenv-webpack` to v6

### DIFF
--- a/variants/frontend-base/sentry/template.rb
+++ b/variants/frontend-base/sentry/template.rb
@@ -2,7 +2,7 @@
 # ############
 
 run "yarn add @sentry/browser"
-run "yarn add dotenv-webpack"
+run "yarn add dotenv-webpack@^6.0.4"
 
 gsub_file "config/webpack/environment.js",
           "module.exports = environment",

--- a/variants/frontend-typescript/template.rb
+++ b/variants/frontend-typescript/template.rb
@@ -8,7 +8,7 @@ types_packages = %w[
   rails__ujs
   actioncable
   turbolinks
-  dotenv-webpack
+  dotenv-webpack@^6.0.4
   postcss-import
   postcss-flexbugs-fixes
   postcss-preset-env


### PR DESCRIPTION
v7 is currently throwing errors on webpack 4: https://github.com/mrsteele/dotenv-webpack/issues/369

This is currently breaking CI, i.e #218