### PR TITLE
feat: use `audit-app` for js auditing

### DIFF
--- a/.auditapprc.json
+++ b/.auditapprc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "node_modules/audit-app/config.schema.json",
+  "ignore": ["1650|lighthouse>jsonld>xmldom"]
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "prettier": "prettier-config-ackama",
   "devDependencies": {
+    "audit-app": "^0.5.2",
     "eslint": "^7.6.0",
     "eslint-config-ackama": "^2.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -2,7 +2,8 @@
 # ######################################
 
 run "rm .browserslistrc"
-run "yarn add --dev eslint eslint-config-ackama eslint-plugin-node eslint-plugin-import eslint-plugin-prettier prettier prettier-config-ackama prettier-plugin-packagejson eslint-plugin-eslint-comments eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y"
+run "yarn add --dev audit-app eslint eslint-config-ackama eslint-plugin-node eslint-plugin-import eslint-plugin-prettier prettier prettier-config-ackama prettier-plugin-packagejson eslint-plugin-eslint-comments eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y"
+copy_file ".auditapprc.json"
 copy_file ".eslintrc.js"
 template ".prettierignore.tt"
 
@@ -92,6 +93,6 @@ append_to_file "bin/ci-run" do
   echo "* ******************************************************"
   echo "* Running JS package audit"
   echo "* ******************************************************"
-  yarn audit
+  npx audit-app
   AUDIT
 end


### PR DESCRIPTION
[`audit-app`](https://www.npmjs.com/package/audit-app) is a tool I wrote to make js auditing a bit nicer in a couple of ways, including supporting ignoring vulnerabilities.

[An advisory for `xmldom` was opened 2 days ago](https://www.npmjs.com/advisories/1650) which is pulled in by `lighthouse` via `jsonld` - the version of `jsonld` being used is very low (which in turn is using a very low version of `xmldom`) meaning we're unlikely to see `lighthouse` release a new version that pulls in the patched version of `xmldom` anytime soon.

Since this means all our CIs will be failing, I feel this is the right time to switch to using `audit-app` in our projects. CodeCare is already using it in our auditing tools, and it's been a nice experience so far.

When the vulnerability we're ignoring is no longer an issue (either its patched or the package is removed), `audit-app` will tell us and fail CI with a non-zero exit code:

```
missing 1 vulnerabilities that were expected to have to ignored
```

I've opened https://github.com/GoogleChrome/lighthouse/issues/12244 to track `lighthouse` getting patched.