### PR TITLE
fix(typescript): pull in valid version of `dotenv-webpack` types

### DIFF
--- a/variants/frontend-typescript/template.rb
+++ b/variants/frontend-typescript/template.rb
@@ -8,7 +8,7 @@ types_packages = %w[
   rails__ujs
   actioncable
   turbolinks
-  dotenv-webpack@^6.0.4
+  dotenv-webpack@^6.0.0
   postcss-import
   postcss-flexbugs-fixes
   postcss-preset-env


### PR DESCRIPTION
[I messed up the version constraint 😅](https://github.com/ackama/rails-template/pull/219/files#r593978317).