### PR TITLE
fix: remove duplicate installing of `@types/actioncable`

### DIFF
--- a/variants/frontend-typescript/template.rb
+++ b/variants/frontend-typescript/template.rb
@@ -7,7 +7,6 @@ types_packages = %w[
   rails__actioncable
   rails__activestorage
   rails__ujs
-  actioncable
   turbolinks
   dotenv-webpack@^6.0.0
   postcss-import


### PR DESCRIPTION
I didn't remove this in #218, and now it's causing conflicts.