### PR TITLE
Adjust rubocop config

### DIFF
--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -66,9 +66,6 @@ Rails/ApplicationRecord:
   Exclude:
     - "db/migrate/**"
 
-Rails/Validation:
-  Enabled: false
-
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
 

--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -66,9 +66,6 @@ Rails/ApplicationRecord:
   Exclude:
     - "db/migrate/**"
 
-Rails/RefuteMethods:
-  Enabled: false
-
 Rails/Validation:
   Enabled: false
 

--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -66,6 +66,12 @@ Rails/ApplicationRecord:
   Exclude:
     - "db/migrate/**"
 
+# we don't require using Rails.logger in lib, as it often doesn't go where
+# we'd want for the code that lives there, or otherwise isn't even available
+Rails/Output:
+  Exclude:
+    - "lib/**/*"
+
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
 

--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -26,9 +26,6 @@ AllCops:
     - Guardfile
     - Rakefile
 
-Layout/SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: no_space
-
 Metrics/AbcSize:
   Exclude:
     - "spec/**/*"


### PR DESCRIPTION
This sprang up from a conversation me & @eoinkelly had when working on a new Rails project - these rules appear like ones we'd actually like to go with the rubocop default, but that were likely disabled back when we had a big shared config file to avoid breaking legacy codebases (the `Rails/` cops) or something that we actually do so rarely we've not really thought about changing the cop (`SpaceAroundEqualsInParameterDefault`).

We're not planning to actively backport these to existing projects.

Happy to discuss if anyone has objections or comments :)