### PR TITLE
ci: don't set `NODE_ENV` to `test` when precompiling assets

### DIFF
--- a/bin/ci-run
+++ b/bin/ci-run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-NODE_ENV=test bundle exec rails webpacker:compile
+bundle exec rails webpacker:compile
 
 SCRIPT_DIR=`dirname "$0"`
 APP_DIR="${SCRIPT_DIR}/.."


### PR DESCRIPTION
The config setup by `@rails/webpacker` and co expect that
`NODE_ENV=test` means you're running tests for JS unit testing, e.g.
with a library like `jest` in a Node process instead of in a real
browser, and so change configuration for tools like babel to target the
current version of node instead of applying all transformations.

Attempting to compile assets with `NODE_ENV=test` will result in errors
because webpack is expecting babel to have transformed new syntax like
the `??` operator for browsers to run the code.

Also see: https://github.com/rails/webpacker/issues/2654