### PR TITLE
Replace sentry-raven with sentry-ruby and variants.

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -15,7 +15,8 @@ gem "turbolinks"<%= gemfile_requirement("turbolinks") %>
 gem "webpacker"<%= gemfile_requirement("webpacker") %>
 gem "lograge"
 gem "okcomputer"
-gem "sentry-raven"
+gem "sentry-ruby"
+gem "sentry-rails"
 
 gem "rack-canonical-host", "~> 0.2.3"
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,13 +1,12 @@
 ##
 # * https://sentry.io/for/rails/
-# * https://github.com/getsentry/raven-ruby
+# * https://github.com/getsentry/sentry-ruby
 #
-Raven.configure do |config|
+Sentry.configure do |config|
   # Sentry will be enabled if SENTRY_DSN exists. Sentry reporting will work if
   # SENTRY_DSN has a meaningful value.
   config.dsn = ENV["SENTRY_DSN"]
 
-  # We expect SENTRY_ENV to always be set so fail with an error if it is
-  # missing
+  # Set Sentry environment to be current environment if SENTRY_ENV is not set
   config.current_environment = ENV.fetch("SENTRY_ENV", Rails.env)
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,11 +2,11 @@
 # * https://sentry.io/for/rails/
 # * https://github.com/getsentry/sentry-ruby
 #
-Sentry.configure do |config|
+Sentry.init do |config|
   # Sentry will be enabled if SENTRY_DSN exists. Sentry reporting will work if
   # SENTRY_DSN has a meaningful value.
   config.dsn = ENV["SENTRY_DSN"]
 
   # Set Sentry environment to be current environment if SENTRY_ENV is not set
-  config.current_environment = ENV.fetch("SENTRY_ENV", Rails.env)
+  config.environment = ENV.fetch("SENTRY_ENV", Rails.env)
 end

--- a/variants/sidekiq/template.rb
+++ b/variants/sidekiq/template.rb
@@ -2,6 +2,7 @@ source_paths.unshift(File.dirname(__FILE__))
 
 
 gem "sidekiq"
+gem "sentry-sidekiq"
 
 run "bundle install"
 run "bundle binstubs sidekiq --force"


### PR DESCRIPTION
Replaces the deprecated sentry-raven gem with sentry-ruby and sentry-rails. Updates initializer. Also adds sentry-sidekiq for sidekiq variant.