### PR TITLE
fix: pin `stylelint` & co packages to working majors

### DIFF
--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -60,9 +60,9 @@ end
 
 # SCSS Linting
 yarn_add_dev_dependencies %w[
-  stylelint
-  stylelint-scss
-  stylelint-config-recommended-scss
+  stylelint@^13.0.0
+  stylelint-scss@^4.0.0
+  stylelint-config-recommended-scss@^4.0.0
 ]
 copy_file ".stylelintrc.js"
 template ".stylelintignore.tt"


### PR DESCRIPTION
`stylelint` & co are currently failing when using the latest versions for reasons I'm not entirely sure but have seen on projects like `eslint` & `@typescript-eslint` when mixing majors - I've not got the time to dig into this, and we'll be using the latest versions possible of all packages anyway so a fix wouldn't be a quick one since it'd need to go through at least one release cycle of a package (and could be multiple packages).

This pins us to versions we know work, to unblock CI for other PRs.