### PR TITLE
Enable new rubocop cops by default

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,11 +14,7 @@ gsub_file "config/environments/production.rb",
             ##
             # `force_ssl` defaults to on. Turn off `force_ssl` if (and only if) RAILS_FORCE_SSL=false.
             #
-            config.force_ssl = if ENV.fetch("RAILS_FORCE_SSL", "").casecmp("false").zero?
-                                 false
-                               else
-                                 true
-                               end
+            config.force_ssl = ENV.fetch("RAILS_FORCE_SSL", "").downcase == "false"
           RUBY
 
 
@@ -36,7 +32,7 @@ insert_into_file "config/environments/production.rb",
 
   config.action_mailer.smtp_settings = {
     address: ENV.fetch("SMTP_HOSTNAME"),
-    port: ENV.fetch("SMTP_PORT", 587), 
+    port: ENV.fetch("SMTP_PORT", 587),
     enable_starttls_auto: true,
     user_name: ENV.fetch("SMTP_USERNAME"),
     password: ENV.fetch("SMTP_PASSWORD"),

--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -8,6 +8,7 @@ inherit_from:
 
 
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
   DisplayStyleGuide: true
   TargetRubyVersion: <%= RUBY_VERSION[/\d+\.\d+/] %>


### PR DESCRIPTION
* It reduces the volume of output from running the template.
* Our track record is that we accept new cops a lot more often than we
  reject them so enabling new cops by default seems sensible.
* Fix minor rubocop failure caused by enabling new cops