### PR TITLE
fix: adjust gemfile requirement regexp to handle `require: false`

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -46,6 +46,7 @@ end
 
 group :test do
   gem "capybara"<%= gemfile_requirement("capybara") %>
+  gem "cucumber"
   gem "mock_redis"
   gem "selenium-webdriver"
   gem "webdrivers"

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -17,6 +17,7 @@ gem "lograge"
 gem "okcomputer"
 gem "sentry-ruby"
 gem "sentry-rails"
+gem "net-http"
 
 gem "rack-canonical-host", "~> 0.2.3"
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ For older versions of Rails, use these branches of @mattbrictson's original repo
 - [Rails 5.0.x](https://github.com/mattbrictson/rails-template/tree/rails-50)
 - [Rails 5.1.x](https://github.com/mattbrictson/rails-template/tree/rails-51)
 - [Rails 5.2.x](https://github.com/mattbrictson/rails-template/tree/rails-52)
+- [Rails 6.0.x](https://github.com/mattbrictson/rails-template/tree/rails-60)
+- [Rails 6.1.x](https://github.com/mattbrictson/rails-template/tree/rails-61)
 
 ## Requirements
 
@@ -25,7 +27,7 @@ For older versions of Rails, use these branches of @mattbrictson's original repo
 
 This template currently works with:
 
-- Rails 6.0.x
+- Rails 7.0.x
 - PostgreSQL
 - chromedriver
 
@@ -46,6 +48,7 @@ To generate a Rails application using this template, pass the `--template` optio
 rails new blog \
   --no-rc \
   --database=postgresql \
+  --skip_javascript \
   --template=https://raw.githubusercontent.com/ackama/rails-template/main/template.rb
 ```
 
@@ -55,6 +58,7 @@ database supported by this template is `postgresql`.
 Here are some additional options you can add to this command. We don't _prescribe_ these,
 but you may find that many Ackama projects are started with some or all of these options:
 
+* `--skip_javascript` skips the setup of JavaScript imports/compilers, Rails 7.0.x is no longer automatically includes [Webpacker](https://github.com/rails/webpacker), instead it uses [Importmap](https://github.com/rails/importmap-rails) by default.
 * `--skip-action-mailbox` skips the setup of ActionMailbox, which you don't need unless you are receiving emails in your application.
 * `--skip-active-storage` skips the setup of ActiveStorage. If you don't need support for file attachments, this can be skipped.
 * `--skip-spring` - you _probably_ want to use this. Spring is great at reducing the start time of Rails processes once

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,6 @@ def setup!
     test "ruby -v" => ruby_version
     run  "gem install bundler --no-document --conservative"
     run  "bundle install"
-    run  "bin/yarn install" if File.exist?("yarn.lock")
     run  "bundle exec overcommit --install"
     copy "example.env"
     copy "config/database.example.yml"

--- a/template-test/ci-run.sh
+++ b/template-test/ci-run.sh
@@ -11,9 +11,16 @@ VARIANT="${VARIANT:-basic}"
 APP_NAME="${VARIANT}-test-app"
 
 rm -rf template-test/dummy/$APP_NAME
+mkdir -p template-test/dummy/$APP_NAME
+
+# otherwise rails webpacker:install initiates yarn init and that overrides these yarn.lock package.json files 
+# exist under the root directory instead of creating new ones under template-test/dummy/$APP_NAME
+cp yarn.lock package.json template-test/dummy/$APP_NAME
+
 cd template-test/dummy
 
-echo -e $GENERATOR_INPUT | RACK_ENV=development RAILS_ENV=development rails new $APP_NAME -d postgresql -m $TEMPLATE
+echo -e $GENERATOR_INPUT | RACK_ENV=development RAILS_ENV=development rails new $APP_NAME -d postgresql -m $TEMPLATE \
+--skip_javascript
 
 cd $ROOT && bash template-test/test.sh template-test/dummy/$APP_NAME
 

--- a/template.rb
+++ b/template.rb
@@ -41,8 +41,6 @@ def apply_template!
   apply "public/template.rb"
   apply "spec/template.rb"
 
-  run "rails webpacker:install"
-
   # The block passed to "after_bundle" seems to run after `bundle install`
   # but also after `webpacker:install` and after Rails has initialized the git
   # repo

--- a/template.rb
+++ b/template.rb
@@ -202,7 +202,7 @@ end
 
 def gemfile_requirement(name)
   @original_gemfile ||= IO.read("Gemfile")
-  req = @original_gemfile[/gem\s+['"]#{name}['"]\s*(,[><~= \t\d\.\w'"]*)?.*$/, 1]
+  req = @original_gemfile[/gem\s+['"]#{name}['"]\s*(, +['"][><~= \t\d\.\w'"]*)?.*$/, 1]
   req && req.gsub("'", %(")).strip.sub(/^,\s*"/, ', "')
 end
 

--- a/template.rb
+++ b/template.rb
@@ -41,6 +41,8 @@ def apply_template!
   apply "public/template.rb"
   apply "spec/template.rb"
 
+  run "rails webpacker:install"
+
   # The block passed to "after_bundle" seems to run after `bundle install`
   # but also after `webpacker:install` and after Rails has initialized the git
   # repo

--- a/template.rb
+++ b/template.rb
@@ -4,7 +4,7 @@ require "fileutils"
 require "shellwords"
 require "pp"
 
-RAILS_REQUIREMENT = "~> 6.1.0".freeze
+RAILS_REQUIREMENT = "~> 7.0.1".freeze
 
 def apply_template!
   assert_minimum_rails_version

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -34,10 +34,6 @@ package_json["scripts"] = {
 
 File.write("./package.json", JSON.generate(package_json))
 
-gsub_file "app/frontend/channels/index.js",
-          "/_channel\\.js$/",
-          "/_channel\\.js$/u"
-
 append_to_file "bin/ci-run" do
   <<~ESLINT
 

--- a/variants/frontend-base/sentry/template.rb
+++ b/variants/frontend-base/sentry/template.rb
@@ -13,9 +13,7 @@ gsub_file "config/webpack/environment.js",
     module.exports = environment;
 EO_JS
 
-insert_into_file "app/frontend/packs/application.js",
-                 "import * as Sentry from '@sentry/browser';\n",
-                 after: /import Rails from "@rails\/ujs"\n/
+prepend_to_file "app/frontend/packs/application.js", "import * as Sentry from '@sentry/browser';"
 
 append_to_file "app/frontend/packs/application.js" do
   <<~'EO_JS'

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -37,25 +37,12 @@ gsub_file "config/webpacker.yml", "  extract_css: false", "  extract_css: true",
 empty_directory_with_keep_file "app/frontend/images"
 copy_file "app/frontend/stylesheets/application.scss"
 copy_file "app/frontend/stylesheets/_elements.scss"
-append_to_file "app/frontend/packs/application.js" do
+prepend_to_file "app/frontend/packs/application.js" do
   <<~EO_CONTENT
 
   import '../stylesheets/application.scss';
   EO_CONTENT
 end
-
-enable_imgs_src = <<~EO_SRC
-  //
-  // const images = require.context('../images', true)
-  // const imagePath = (name) => images(name, true)
-EO_SRC
-enable_imgs_replacement = <<~EO_REPLACEMENT
-
-  const images = require.context('../images', true);
-  // eslint-disable-next-line no-unused-vars
-  const imagePath = name => images(name, true);
-EO_REPLACEMENT
-gsub_file "app/frontend/packs/application.js", enable_imgs_src, enable_imgs_replacement
 
 # Configure app/views
 gsub_file "app/views/layouts/application.html.erb",

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -13,6 +13,8 @@ end
 remove_dir "app/assets/stylesheets"
 remove_dir "app/assets/images"
 
+run "rails webpacker:install"
+
 # Configure app/frontend
 
 run "mv app/javascript app/frontend"

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -32,8 +32,11 @@ gsub_file "app/frontend/packs/server_rendering.js",
 gsub_file(
   "app/frontend/packs/application.js",
   'var ReactRailsUJS = require("react_ujs")',
-  "import ReactRailsUJS from 'react_ujs';"
+  ""
 )
+
+prepend_to_file "app/frontend/packs/application.js",
+                 "import ReactRailsUJS from 'react_ujs';\n"
 
 gsub_file(
   "app/frontend/packs/server_rendering.js",

--- a/variants/frontend-typescript/template.rb
+++ b/variants/frontend-typescript/template.rb
@@ -23,8 +23,6 @@ yarn_add_dev_dependencies %w[@typescript-eslint/parser @typescript-eslint/eslint
 run "yarn install"
 
 %w[
-  app/frontend/channels/consumer
-  app/frontend/channels/index
   app/frontend/packs/application
   app/frontend/packs/server_rendering
 ].each do |file|
@@ -36,7 +34,6 @@ copy_file "tsconfig.json", force: true
 copy_file ".eslintrc.js", force: true
 copy_file "types.d.ts", force: true
 
-gsub_file "app/frontend/channels/index.ts", '_channel\.js', '_channel\.ts'
 gsub_file(
   "app/frontend/packs/application.ts",
   "process.env.SENTRY_ENV || process.env.RAILS_ENV",


### PR DESCRIPTION
The regexp now requires that after the comma there is "zero or more"
spaces followed by either a single or double quote, _then_ zero or more
of our specific characters that could be used in a version constraint.

This fix is needed because Rails 7 now doesn't require `bootsnap`,
meaning we'd end up creating an invalid Gemfile by inserting `gem
"bootsnap", require, require: false`.

-----

Example of it in action:

```ruby
# file-new-regexp.rb
def gemfile_requirement(name)
  @original_gemfile ||= IO.read("the-gemfile") # different name because bundler would try and be helpful
  req = @original_gemfile[/gem\s+['"]#{name}['"]\s*(, +['"][><~= \t\d\.\w'"]*)?.*$/, 1]
  req && req.gsub("'", %(")).strip.sub(/^,\s*"/, ', "')
end

pp gemfile_requirement("bootsnap1")
pp gemfile_requirement("bootsnap2")
pp gemfile_requirement("bootsnap3")
pp gemfile_requirement("bootsnap4")
```

```ruby
# the-gemfile
gem "bootsnap1", require: false
gem "bootsnap2", ">= 1.4.4"
gem "bootsnap3", ">= 1.4.4", require: false
gem "bootsnap4", require: false, ">= 1.4.4"
```

```
❯ ruby file-old-regexp.rb
", require"
", \">= 1.4.4\""
", \">= 1.4.4\""
", require"

❯ ruby file-new-regexp.rb
nil
", \">= 1.4.4\""
", \">= 1.4.4\""
nil
```