### PR TITLE
Tweak rubocop settings to match Ackama preferences

### DIFF
--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -104,4 +104,7 @@ RSpec/MultipleExpectations:
   Max: 10
 
 RSpec/ExampleLength:
-  Max: 20
+  Max: 30
+
+RSpec/FactoryBot/SyntaxMethods:
+  Enabled: false


### PR DESCRIPTION
The ExampleLength is causing PR #257 to fail. I don't think long examples are a problem. In fact they are something to encourage if the test setup is slow e.g. feature specs. I have bumped the limit to 30 to reflect this.

`RSpec/FactoryBot/SyntaxMethods` fails if we use `FactoryBot.create` instead of `create` in tests which seems a bit too magical for it's own good and we have rough consensus about that on Slack.