### PR TITLE
feat: add react testing library to react variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,13 +215,14 @@ Noteabley, these files generate a User model with devise `:validatable` and `:lo
 #### frontend-react
 adds configuration, example of react, which is based on [rails-react](https://github.com/reactjs/react-rails)
 
-The relevant config files are found in `variants/frontend-react`
+The relevant config files are found in `variants/frontend-react`.
+
+An example react test using [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/) is provided. Before you start adding more tests, it is recommended you read [common-mistakes-with-react-testing-library](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)
 
 #### sidekiq
 A job scheduler is a computer application for controlling unattended background program execution of jobs
 
 Note that the non enterprise version of [Sidekiq](https://github.com/mperham/sidekiq) doesn't do scheduling by default, it only executes jobs
-
 
 
 

--- a/variants/frontend-react/.eslintrc.js
+++ b/variants/frontend-react/.eslintrc.js
@@ -15,6 +15,19 @@ const config = {
         '.eslintrc.js'
       ],
       parserOptions: { sourceType: 'script' }
+    },
+    {
+      files: ['app/frontend/test/**'],
+      extends: [
+        'ackama/jest',
+        'plugin:jest-dom/recommended',
+        'plugin:testing-library/dom',
+        'plugin:testing-library/react'
+      ],
+      plugins: ['testing-library', 'jest-dom'],
+      rules: {
+        'jest/prefer-expect-assertions': 'off'
+      }
     }
   ]
 };

--- a/variants/frontend-react/app/frontend/components/HelloWorld.jsx
+++ b/variants/frontend-react/app/frontend/components/HelloWorld.jsx
@@ -1,10 +1,26 @@
 import * as PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 
-const HelloWorld = ({ greeting }) => <>Greeting: {greeting}</>;
+const HelloWorld = ({ initialGreeting }) => {
+  const [greeting, setGreeting] = useState(initialGreeting);
+
+  const updateGreeting = event => {
+    setGreeting(event.target.value);
+  };
+
+  return (
+    <>
+      <b>{greeting}</b>
+      <label htmlFor="greeting-input">
+        Change the greeting
+        <input id="greeting-input" type="text" onChange={updateGreeting} />
+      </label>
+    </>
+  );
+};
 
 HelloWorld.propTypes = {
-  greeting: PropTypes.string.isRequired
+  initialGreeting: PropTypes.string.isRequired
 };
 
 export default HelloWorld;

--- a/variants/frontend-react/app/frontend/components/HelloWorld.jsx
+++ b/variants/frontend-react/app/frontend/components/HelloWorld.jsx
@@ -8,6 +8,10 @@ const HelloWorld = ({ initialGreeting }) => {
     setGreeting(event.target.value);
   };
 
+  const resetGreeting = () => {
+    setGreeting(initialGreeting);
+  };
+
   return (
     <>
       <b>{greeting}</b>
@@ -15,6 +19,7 @@ const HelloWorld = ({ initialGreeting }) => {
         Change the greeting
         <input id="greeting-input" type="text" onChange={updateGreeting} />
       </label>
+      <button onClick={resetGreeting}>Reset</button>
     </>
   );
 };

--- a/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
+++ b/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
@@ -25,5 +25,26 @@ describe('HelloWorld', () => {
 
       expect(container).toHaveTextContent(/Hello from the other side/iu);
     });
+
+    it('can be reset back to the initial greeting', async () => {
+      const { container } = render(
+        <HelloWorld initialGreeting="Hello Ackama" />
+      );
+
+      userEvent.type(
+        screen.getByRole('textbox', {
+          name: /change the greeting/iu
+        }),
+        'Hello from the other side'
+      );
+
+      expect(container).not.toHaveTextContent("Hello Ackama");
+
+      userEvent.click(
+        screen.getByText('Reset')
+      )
+
+      expect(container).toHaveTextContent("Hello Ackama");
+    });
   });
 });

--- a/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
+++ b/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import HelloWorld from '../../components/HelloWorld';
+
+describe('HelloWorld', () => {
+  it('renders the initial greeting', async () => {
+    const { container } = render(<HelloWorld initialGreeting="Hello Ackama" />);
+
+    expect(container).toHaveTextContent(/Hello Ackama/iu);
+  });
+
+  describe('when the user types in a new greeting', () => {
+    it('changes to render that one', async () => {
+      const { container } = render(
+        <HelloWorld initialGreeting="Hello Ackama" />
+      );
+
+      userEvent.type(
+        screen.getByRole('textbox', {
+          name: /change the greeting/iu
+        }),
+        'Hello from the other side'
+      );
+
+      expect(container).toHaveTextContent(/Hello from the other side/iu);
+    });
+  });
+});

--- a/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
+++ b/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
@@ -4,14 +4,14 @@ import React from 'react';
 import HelloWorld from '../../components/HelloWorld';
 
 describe('HelloWorld', () => {
-  it('renders the initial greeting', async () => {
+  it('renders the initial greeting', () => {
     const { container } = render(<HelloWorld initialGreeting="Hello Ackama" />);
 
     expect(container).toHaveTextContent(/Hello Ackama/iu);
   });
 
   describe('when the user types in a new greeting', () => {
-    it('changes to render that one', async () => {
+    it('changes to render that one', () => {
       const { container } = render(
         <HelloWorld initialGreeting="Hello Ackama" />
       );
@@ -26,7 +26,7 @@ describe('HelloWorld', () => {
       expect(container).toHaveTextContent(/Hello from the other side/iu);
     });
 
-    it('can be reset back to the initial greeting', async () => {
+    it('can be reset back to the initial greeting', () => {
       const { container } = render(
         <HelloWorld initialGreeting="Hello Ackama" />
       );

--- a/variants/frontend-react/app/frontend/test/setupExpectEachTestHasAssertions.js
+++ b/variants/frontend-react/app/frontend/test/setupExpectEachTestHasAssertions.js
@@ -1,0 +1,5 @@
+/**
+ * Sets up before each test an expectation for there to be assertions.
+ */
+// eslint-disable-next-line jest/require-top-level-describe
+beforeEach(() => expect.hasAssertions());

--- a/variants/frontend-react/jest.config.js
+++ b/variants/frontend-react/jest.config.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const config = {
+  clearMocks: true,
+  restoreMocks: true,
+  resetMocks: true,
+
+  testEnvironment: 'jsdom',
+
+  testPathIgnorePatterns: ['config/'],
+  setupFilesAfterEnv: [
+    '@testing-library/jest-dom/extend-expect',
+    './app/frontend/test/setupExpectEachTestHasAssertions.js'
+  ]
+};
+
+module.exports = config;


### PR DESCRIPTION
This adds [react-testing-library](https://testing-library.com/docs/react-testing-library/intro/) to the react variant, along with a sample test & linting configuration.

Closes #216
Closes #208