### PR TITLE
Fix: using --skip options fails to generate apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,22 @@ jobs:
         variant:
           - name: basic
             generator_input: example.com\nstaging.example.com\nN\nN\nNo\nNo\n\nNo\n
+            skips: --skip-javascript
           - name: react
             generator_input: example.com\nstaging.example.com\nY\nN\nNo\nNo\n\nNo\n
+            skips: --skip-javascript
           - name: typescript
             generator_input: example.com\nstaging.example.com\nN\nY\nNo\nNo\n\nNo\n
+            skips: --skip-javascript
           - name: sidekiq
             generator_input: example.com\nstaging.example.com\nN\nN\nNo\nYes\n\nNo\n
+            skips: --skip-javascript
           - name: devise
             generator_input: example.com\nstaging.example.com\nN\nN\nNo\nNo\n\nYes\nYes\n
+            skips: --skip-javascript
+          - name: basic_with_skips
+            generator_input: example.com\nstaging.example.com\nN\nN\nNo\nNo\n\nNo\n
+            skips: --skip-active-storage --skip-spring --skip-javascript
     services:
       db:
         image: postgres
@@ -72,6 +80,7 @@ jobs:
         env:
           VARIANT: ${{ matrix.variant.name }}
           GENERATOR_INPUT: ${{ matrix.variant.generator_input }}
+          SKIPS: ${{ matrix.variant.skips }}
           PGUSER: postgres
           PGPASSWORD: postgres
           PGHOST: localhost

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,11 +2,11 @@ gsub_file "config/application.rb",
           "# config.time_zone = 'Central Time (US & Canada)'",
           "config.time_zone = 'Wellington'"
 
-insert_into_file "config/application.rb", after: /^require ['"]rails\/all['"]/ do
+insert_into_file "config/application.rb", after: /^require_relative ['"]boot['"]/ do
   # the empty line at the beginning of this string is required
   <<-'RUBY'
 
-    require_relative '../app/middleware/http_basic_auth'
+require_relative '../app/middleware/http_basic_auth'
   RUBY
 end
 

--- a/config/template.rb
+++ b/config/template.rb
@@ -73,4 +73,4 @@ gsub_file "config/storage.yml", /#   service: S3/ do
     #     #
     #     cache_control: 'private, max-age=<%= 365.days.seconds %>'
   YAML
-end
+end if File.exist? "config/storage.yml"

--- a/template-test/ci-run.sh
+++ b/template-test/ci-run.sh
@@ -9,12 +9,12 @@ mkdir -p template-test/dummy
 # Basic run
 VARIANT="${VARIANT:-basic}"
 APP_NAME="${VARIANT}-test-app"
+SKIPS="${SKIPS:-''}"
 
 rm -rf template-test/dummy/$APP_NAME
 cd template-test/dummy
 
-echo -e $GENERATOR_INPUT | RACK_ENV=development RAILS_ENV=development rails new $APP_NAME -d postgresql -m $TEMPLATE \
-  --skip_javascript
+echo -e $GENERATOR_INPUT | RACK_ENV=development RAILS_ENV=development rails new $APP_NAME -d postgresql -m $TEMPLATE $SKIPS
 
 cd $ROOT && bash template-test/test.sh template-test/dummy/$APP_NAME
 


### PR DESCRIPTION
Two major fixes:
1) Move the insertion of `require_relative '../app/middleware/http_basic_auth'` to after `require_relative 'boot'` to ensure that the HttpBasicAuth constants get initialized.
2) Skip writing to `storage.yml` if that file doesn't exist (which it doesn't when `--skip-active-storage` is set)

Also adds a new variable `SKIPS` in the CI run that allows us to have a run that can include skip flags. Have moved the "always skip javascript" line that was added for Rails 7 to this section so that it's always in one place.

Closes #107 and #108 