### PR TITLE
Load SimpleCov config from just one place: spec/spec_helper.rb

### DIFF
--- a/simplecov
+++ b/simplecov
@@ -1,8 +1,0 @@
-require "simplecov"
-SimpleCov.start("rails") do
-  add_filter("/bin/")
-  add_filter("/lib/tasks/auto_annotate_models.rake")
-  add_filter("/lib/tasks/coverage.rake")
-end
-SimpleCov.minimum_coverage(75)
-SimpleCov.use_merging(false)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,12 @@ SimpleCov.minimum_coverage 90
 # SimpleCov.minimum_coverage_by_file 80
 # SimpleCov.maximum_coverage_drop 5
 # SimpleCov.refuse_coverage_drop
+SimpleCov.use_merging false
 
 SimpleCov.start do
+  add_filter "/bin/"
+  add_filter "/lib/tasks/auto_annotate_models.rake"
+  add_filter "/lib/tasks/coverage.rake"
   add_filter "/spec/support/"
   add_filter "/spec/factories/"
   add_filter "/spec/rails_helper.rb"

--- a/template.rb
+++ b/template.rb
@@ -72,7 +72,6 @@ def apply_template!
   copy_file "gitignore", ".gitignore", force: true
   copy_file "overcommit.yml", ".overcommit.yml"
   template "ruby-version.tt", ".ruby-version", force: true
-  copy_file "simplecov", ".simplecov"
 
   copy_file "Procfile"
 


### PR DESCRIPTION
After this change we no longer create a `.simplecov` file. I think that
keeping the config in `spec/spec_helper.rb` is less surprising.

This also resolves an issue where the SimpleCov setup in `.simplecov`
was different to that in `spec/spec_helper.rb`.