### PR TITLE
Raise an ActiveRecord::RecordNotFound if the user is not authorised

### DIFF
--- a/variants/pundit/template.rb
+++ b/variants/pundit/template.rb
@@ -29,8 +29,35 @@ insert_into_file "app/controllers/application_controller.rb", before: /^end/ do
   private
 
   def user_not_authorized
-    flash[:alert] = I18n.t("authorization.not_authorized")
-    redirect_to(request.referer || root_path)
+    # This application uses the Rails default of increasing numeric IDs for
+    # records in the database.
+    #
+    # This means there are security implications to how you inform a user that
+    # they are not authorized.  If this app returns a different error message
+    # depending on whether the resource exists or not, then a (potentially
+    # malicious) user could use the different error messages to discover how
+    # many instances of a model exist in the database. Depending on the context,
+    # this could be a serious security issue e.g.
+    #
+    # * a competitor could find out how many users have signed up
+    # * an attacker could guess what the next user ID would be which might be
+    #   useful to them in another context
+    #
+    # This template defaults to the more secure (but less user-friendly) option
+    # of making Pundit authorization errors look like
+    # ActiveRecord::RecordNotFound errors (returning the standard Rails 404
+    # page). You may choose to use the more user-friendly version in your
+    # application but be aware of the security consequences and that the team
+    # will almost certainly have to defend the choice in a penetration test.
+
+    # The more secure but less user-friendly option (our default):
+    # ############################################################
+    raise ActiveRecord::RecordNotFound
+
+    # The user-friendly but less secure option:
+    # #########################################
+    # flash[:alert] = I18n.t("authorization.not_authorized")
+    # redirect_to(request.referer || root_path)
   end
   RUBY
 end

--- a/variants/pundit/template.rb
+++ b/variants/pundit/template.rb
@@ -33,7 +33,7 @@ insert_into_file "app/controllers/application_controller.rb", before: /^end/ do
     # records in the database.
     #
     # This means there are security implications to how you inform a user that
-    # they are not authorized.  If this app returns a different error message
+    # they are not authorized. If this app returns a different error message
     # depending on whether the resource exists or not, then a (potentially
     # malicious) user could use the different error messages to discover how
     # many instances of a model exist in the database. Depending on the context,


### PR DESCRIPTION
Raise an ActiveRecord::RecordNotFound if the user is not authorised so
that the user sees the same error message for unauthorised access and
missing resource. This prevents the user from enumerating which
resources exist in the database and addresses an issue which was raised
in a pen test.

I have left the original code in the method (commented out) so that users have access to a good implementation of the user-friendly version. I'm not :100: this is the right move so feedback particularly welcome on that.