### PR TITLE
Make Sidekiq raise an error if job args do not serialize safely to JSON

### DIFF
--- a/variants/sidekiq/config/initializers/sidekiq.rb.tt
+++ b/variants/sidekiq/config/initializers/sidekiq.rb.tt
@@ -8,3 +8,8 @@ Sidekiq::Web.use(Rack::Auth::Basic, "Application") do |username, password|
   username == sidekiq_username &&
     ActiveSupport::SecurityUtils.secure_compare(password, sidekiq_password)
 end
+
+# Job arguments which do not serialize to JSON safely will raise an error in
+# Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices. We set
+# `strict_args!` to raise an error today and make upgrading to Sidekiq 7 easier.
+Sidekiq.strict_args!


### PR DESCRIPTION
This error will be a default in Sidekiq 7+ so we are explicitly raising
the error now to make upgrading Sidekiq easier. Details in
https://github.com/mperham/sidekiq/wiki/Best-Practices.

Closes #298