### PR TITLE
fix: remove `TargetRubyVersion` from rubocop config

### DIFF
--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -20,7 +20,6 @@ AllCops:
   NewCops: enable
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: <%= RUBY_VERSION[/\d+\.\d+/] %>
   Exclude:
     - 'bin/*'
     - Capfile


### PR DESCRIPTION
It's automatically inferred from `.ruby-version` (if it exists) and `Gemfile.lock` (if it has the ruby version), which both exist in this template, meaning explicitly defining it just adds another change that needs to be made when upgrading apps to newer versions of Ruby.

(the purpose of this config property is in case you target a range of Ruby versions and want Rubocop to only use syntax from the lowest version you support to help ensure compatibility - useful if you're a library, but not if you're an application)

https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version

