### PR TITLE
fix: make `RAILS_CACHE_REDIS_URL` env properly optional

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ end
 insert_into_file "config/environments/production.rb",
   after: /.*config.cache_store = :mem_cache_store\n/ do
   <<~'RUBY'
-    if ENV.fetch("RAILS_CACHE_REDIS_URL")
+    if ENV.fetch("RAILS_CACHE_REDIS_URL", nil)
       config.cache_store = :redis_cache_store, {
         url: ENV.fetch("RAILS_CACHE_REDIS_URL"),
         ##


### PR DESCRIPTION
I missed this when reviewing #296 - I'm also getting an error about the `redis` gem not being in the Gemfile, but not sure if we want to be including that by default since we can't make it conditional like we can with actually trying to use Redis; the error message is helpful enough that I think we don't need to do anything if we're happy with the gem needing to be added manually.