### PR TITLE
feat: enable a few more stylelint rules

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,16 @@
 module.exports = {
   plugins: ['stylelint-scss'],
   extends: ['stylelint-config-recommended-scss'],
-  rules: { 'no-descending-specificity': null }
+  rules: {
+    'no-descending-specificity': null,
+    'string-no-newline': true,
+    'color-no-invalid-hex': true,
+    'comment-whitespace-inside': 'always',
+    'declaration-block-no-duplicate-custom-properties': true,
+    'declaration-block-no-duplicate-properties': true,
+    'no-invalid-double-slash-comments': true,
+    'no-duplicate-at-import-rules': true,
+    'no-invalid-position-at-import-rule': true,
+    'length-zero-no-unit': true
+  }
 };


### PR DESCRIPTION
This enables a few more stylelint rules that I think are pretty straightforward as most of them are for catching invalid syntax.

I've not enabled any stylistic ones like enforcing no consecutive empty lines because those rules have actually been deprecated in stylelint in favor of formatters like `prettier`, which is what we use anyway on our scss files. I might look into setting up [`stylelint-prettier`](https://github.com/prettier/stylelint-prettier) in another PR.