### PR TITLE
Force yarn to use the exact version of bootstrap we have specified

### DIFF
--- a/variants/frontend-bootstrap/template.rb
+++ b/variants/frontend-bootstrap/template.rb
@@ -1,6 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-yarn_add_dependencies %w[bootstrap@5.1.3 @popperjs/core]
+yarn_add_dependencies(["bootstrap@5.1.3 --exact", "@popperjs/core"])
 run "yarn install"
 
 copy_file "app/frontend/js/bootstrap.js", force: true


### PR DESCRIPTION
Without `--exact`, yarn will add `^5.1.3` to `yarn.lock` which allows `5.2.0`,
the version which is currently broken for us