### PR TITLE
fix: update react typescript variant to be compatible with react18 types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           - name: react
             config_path: "ci/configs/react.yml"
             skips: --skip-javascript
-          - name: typescript
-            config_path: "ci/configs/typescript.yml"
+          - name: react-typescript
+            config_path: "ci/configs/react-typescript.yml"
             skips: --skip-javascript
           - name: sidekiq
             config_path: "ci/configs/sidekiq.yml"

--- a/ci/configs/react-typescript.yml
+++ b/ci/configs/react-typescript.yml
@@ -2,7 +2,7 @@
 staging_hostname: "staging.example.com"
 production_hostname: "www.example.com"
 git_repo_url: ""
-apply_variant_react: false
+apply_variant_react: true
 apply_variant_devise: false
 apply_variant_sidekiq: false
 apply_variant_typescript: true

--- a/variants/frontend-typescript/app/frontend/components/utils/Form.tsx
+++ b/variants/frontend-typescript/app/frontend/components/utils/Form.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 interface Props {
+  children?: React.ReactNode;
   submitText?: string;
 
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;


### PR DESCRIPTION
Because of this right now we're not actually testing the TypeScript variant, and also this means I can avoid a conflict in #309 & #283 (which is why I've also renamed the file)

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210