### PR TITLE
Uncomment SMTP_* env vars required to run app in production env

### DIFF
--- a/example.env.tt
+++ b/example.env.tt
@@ -14,7 +14,7 @@
 # port is in use.
 SMTP_USERNAME=example
 SMTP_PASSWORD=example
-SMTP_HOSTNAME=localhost
+SMTP_HOSTNAME=example.invalid
 
 MAIL_FROM=changeme@example.com
 RAILS_SECRET_KEY_BASE=<%= SecureRandom.hex(64) %>

--- a/example.env.tt
+++ b/example.env.tt
@@ -12,10 +12,9 @@
 # The environment variables below need to be provided in staging/production environments
 # with outgoing mail. SMTP_PORT defaults to 587 so only needs to be provided if a different
 # port is in use.
-# SMTP_USERNAME=example
-# SMTP_PASSWORD=example
-# SMTP_HOSTNAME=example
-
+SMTP_USERNAME=example
+SMTP_PASSWORD=example
+SMTP_HOSTNAME=localhost
 
 MAIL_FROM=changeme@example.com
 RAILS_SECRET_KEY_BASE=<%= SecureRandom.hex(64) %>


### PR DESCRIPTION
Rails will not boot in production env without these env vars. It is
sometimes convenient to boot the app in production env locally for
debugging (we already document this in the README).

Uncommenting these lines is safe to do and is one less papercut for
doing this.

Closes #327