### PR TITLE
Rename canonical hostname env var to avoid pre-defined env vars

### DIFF
--- a/config.ru.rb
+++ b/config.ru.rb
@@ -1,5 +1,5 @@
 insert_into_file "config.ru", before: /^run Rails.application/ do
   <<~RUBY
-    use Rack::CanonicalHost, ENV["HOSTNAME"] if ENV["HOSTNAME"].present?
+    use Rack::CanonicalHost, ENV["CANONICAL_HOSTNAME"] if ENV["CANONICAL_HOSTNAME"].present?
   RUBY
 end


### PR DESCRIPTION
Before this change, we use
[rack-canonical-host](https://github.com/tylerhunt/rack-canonical-host)
with the `HOSTNAME` env var. This can clash with an env var already
defined by the deployed environment e.g. https://render.com

Render.com sets `HOSTNAME` but doesn't set
it to a fully qualified domain e.g. it sets it to something like
`HOSTNAME=srv-cbm836fho1kta1m6cu6g-5fb64bb76c-qvsd5`. This means our
setup in `config.ru` breaks out of the box because we try to HTTP 301 to
`https://srv-cbm836fho1kta1m6cu6g-5fb64bb76c-qvsd5/`. This also doesn't
generate any logging output so is quite confusing to debug.

This change renames the env var we use for `rack-canonical-host` to
`CANONICAL_HOSTNAME` to avoid this clash.

Closes #328