### PR TITLE
Fix the logic for force_ssl to match the comment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,9 +12,9 @@ gsub_file "config/environments/production.rb",
           "# config.force_ssl = true",
           <<~RUBY
             ##
-            # `force_ssl` defaults to on. Turn off `force_ssl` if (and only if) RAILS_FORCE_SSL=false.
+            # `force_ssl` defaults to on. Set `force_ssl` to false if (and only if) RAILS_FORCE_SSL=false, otherwise set it to true.
             #
-            config.force_ssl = ENV.fetch("RAILS_FORCE_SSL", "").downcase == "false"
+            config.force_ssl = ENV.fetch("RAILS_FORCE_SSL", "true").downcase != "false"
           RUBY
 
 insert_into_file "config/environments/production.rb",


### PR DESCRIPTION
and make the comment clearer

this logic seems to have been inverted in
a2ac42b86906eba4036ceed6a527a3effc8ece34

i added 'true' as the default for the fetch argument for clarity of intent only, if this env variable isn't present then treat it as true