### PR TITLE
chore: disable jest linting rule

### DIFF
--- a/variants/frontend-react/app/frontend/test/setupExpectEachTestHasAssertions.js
+++ b/variants/frontend-react/app/frontend/test/setupExpectEachTestHasAssertions.js
@@ -1,5 +1,5 @@
 /**
  * Sets up before each test an expectation for there to be assertions.
  */
-// eslint-disable-next-line jest/require-top-level-describe
+// eslint-disable-next-line jest/require-top-level-describe, jest/no-standalone-expect
 beforeEach(() => expect.hasAssertions());

--- a/variants/frontend-typescript/app/frontend/test/setupExpectEachTestHasAssertions.ts
+++ b/variants/frontend-typescript/app/frontend/test/setupExpectEachTestHasAssertions.ts
@@ -1,5 +1,5 @@
 /**
  * Sets up before each test an expectation for there to be assertions.
  */
-// eslint-disable-next-line jest/require-top-level-describe
+// eslint-disable-next-line jest/require-top-level-describe, jest/no-standalone-expect
 beforeEach(() => expect.hasAssertions());


### PR DESCRIPTION
I landed a huge improvement to how we check for `expect` calls over in `eslint-plugin-jest`, which means `no-standalone-expect` is now _correctly_ flagging this call as a standalone `expect` since it's not in a describe.

Our usage here is valid, it's not just supported by `no-standalone-expect` as it's considered an advanced usage and it's a one-liner to disable like this (vs having people stumble into finding it is considered valid without knowing how it's meant to be used)