### PR TITLE
Fix latest 'jest' and 'ts-jest' versions not being compatible

### DIFF
--- a/variants/frontend-react-typescript/template.rb
+++ b/variants/frontend-react-typescript/template.rb
@@ -15,14 +15,16 @@ types_packages = %w[
   react-dom
 ].map { |name| "@types/#{name}" }
 
+installed_jest_major_version = JSON.parse(File.read("node_modules/jest/package.json")).fetch("version").split(".").first
+
 run "yarn remove prop-types"
 yarn_add_dependencies types_packages + %w[@babel/preset-typescript typescript]
-yarn_add_dev_dependencies %w[
-  @typescript-eslint/parser
-  @typescript-eslint/eslint-plugin
-  @jest/types
-  ts-jest
-  ts-node
+yarn_add_dev_dependencies [
+  "@typescript-eslint/parser",
+  "@typescript-eslint/eslint-plugin",
+  "@jest/types@#{installed_jest_major_version}",
+  "ts-jest@#{installed_jest_major_version}",
+  "ts-node"
 ]
 run "yarn install"
 

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -15,19 +15,23 @@ yarn_add_dependencies %w[
   prop-types
 ]
 
-yarn_add_dev_dependencies %w[
-  @testing-library/react
-  @testing-library/jest-dom
-  @testing-library/user-event
-  eslint-plugin-react
-  eslint-plugin-react-hooks
-  eslint-plugin-jsx-a11y
-  eslint-plugin-jest
-  eslint-plugin-jest-formatting
-  eslint-plugin-jest-dom
-  eslint-plugin-testing-library
-  jest-environment-jsdom
-  jest
+# We need the major version of the 'jest', '@jest/types', 'ts-jest' packages to
+# match so we can only upgrade jest when there are compatible versions available
+jest_major_version = "28"
+
+yarn_add_dev_dependencies [
+  "@testing-library/react",
+  "@testing-library/jest-dom",
+  "@testing-library/user-event",
+  "eslint-plugin-react",
+  "eslint-plugin-react-hooks",
+  "eslint-plugin-jsx-a11y",
+  "eslint-plugin-jest",
+  "eslint-plugin-jest-formatting",
+  "eslint-plugin-jest-dom",
+  "eslint-plugin-testing-library",
+  "jest-environment-jsdom",
+  "jest@#{jest_major_version}"
 ]
 copy_file ".eslintrc.js", force: true
 copy_file "babel.config.js", force: true


### PR DESCRIPTION
* Allow pinning of the major version of `jest` package to ensure that it
  installs a version which has an available `ts-jest` package.

This fixes an issue where CI cannot currently build the react-ts variant.