### PR TITLE
feat: switch to Jest v29

### DIFF
--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -17,7 +17,7 @@ yarn_add_dependencies %w[
 
 # We need the major version of the 'jest', '@jest/types', 'ts-jest' packages to
 # match so we can only upgrade jest when there are compatible versions available
-jest_major_version = "28"
+jest_major_version = "29"
 
 yarn_add_dev_dependencies [
   "@testing-library/react",


### PR DESCRIPTION
`ts-jest` has released v29, so hopefully this should be fine.