### PR TITLE
Fixes for Github Actions

### DIFF
--- a/config/database.yml.tt
+++ b/config/database.yml.tt
@@ -7,6 +7,9 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%%= ENV["DB_POOL_SIZE"] || ENV["RAILS_MAX_THREADS"] || 5 %>
   min_messages: WARNING # https://thoughtbot.com/blog/global-min-messages
+  host: <%= ENV.fetch("PGHOST", "localhost") %>
+  username: <%= ENV.fetch("POSTGRES_USER", "postgres") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD", "postgres") %>
 
 development:
   <<: *default

--- a/variants/github_actions_ci/workflows/ci.yml
+++ b/variants/github_actions_ci/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - run: bin/setup
       - run: bundle exec rubocop
       - run: bundle exec brakeman --run-all-checks --exit-on-warn --format plain .
       - run: bundle exec bundle audit --update
-      - run: bundle exec rails db:setup
       - run: bundle exec rspec spec --format progress
 
   # ACTION REQUIRED:


### PR DESCRIPTION
This changeset resolves issues I had with Github Actions not passing on a new Rails application with all the trimmings:

1. Actions started a DB container, but the new version of database.yml doesn't pick up the env vars to connect to the database. I'm happy to bikeshed what we name the env vars since the current naming scheme is not compatible with [the `libpq` defaults](https://www.postgresql.org/docs/current/libpq-envars.html)
2. Actions was running `rails db:setup`, which is not representative of the complete set of steps that an app might need to run tests. In particular, Sidekiq provisions SIDEKIQ_WEB_USERNAME which is expected to be present. I think the least surprising thing is for actions to run bin/setup to copy environment variables, migrate & seed the database, and anything else the app might consider 'setup'.