### PR TITLE
Set up Rails route and model code annotations

### DIFF
--- a/README.md.tt
+++ b/README.md.tt
@@ -165,6 +165,26 @@ HEADFUL=1 bundle exec rspec spec/features
 npm run lighthouse-spec
 ```
 
+### Source code annotations
+
+The [chusaku](https://github.com/nshki/chusaku) and
+[annotate](https://github.com/ctran/annotate_models) gems are installed in
+development. Chusaku annotates controller actions with a comment detailing the
+route. Annotate annotates models and fixtures with a comment detailing the DB
+schema. You can run them manually via:
+
+```bash
+# update controller action annotation comments
+bundle exec chusaku
+
+# update model, fixture, spec annotation comments (not usually required, auto-runs on migrations)
+bundle exec annotate
+```
+
+Annotate runs automatically after migrations. You will have to run Chusaku
+manually after you add controller actions. CI verifies that these annotations
+are up to date.
+
 ### Rake tasks
 
 ```

--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -58,6 +58,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
     - 'config/**/*'
+    - 'lib/tasks/**/*'
 
 # We generally don't want methods longer than 15 lines, except in migrations where it's probably okay.
 Metrics/MethodLength:

--- a/template.rb
+++ b/template.rb
@@ -62,8 +62,17 @@ class Config
   end
 end
 
+class Terminal
+  def puts_header(msg)
+    puts "=" * 80
+    puts msg
+    puts "=" * 80
+  end
+end
+
 # Allow access to our configuration as a global
 TEMPLATE_CONFIG = Config.new
+TERMINAL = Terminal.new
 
 def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   assert_minimum_rails_version
@@ -169,6 +178,10 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
     # we deliberately place this after the initial git commit because it
     # contains a lot of changes and adds its own git commit
     apply "variants/devise/template.rb" if TEMPLATE_CONFIG.apply_variant_devise?
+
+    # We apply code annotation **after** all the other variants which might
+    # generate routes and models
+    apply "variants/code-annotation/template.rb"
   end
 end
 

--- a/variants/code-annotation/template.rb
+++ b/variants/code-annotation/template.rb
@@ -1,0 +1,28 @@
+# Allow us to copy file with root at the directory this file is in
+source_paths.unshift(File.dirname(__FILE__))
+
+TERMINAL.puts_header "Installing code annotation gems"
+
+insert_into_file "Gemfile", after: /group :development do\n/ do
+  <<-GEMS
+  # code annotation
+  gem "chusaku", require: false
+  gem "annotate", require: false
+
+  GEMS
+end
+
+run "bundle install"
+
+# adds a rake task which causes annotate to auto-run on every migration
+run "bundle exec rails generate annotate:install"
+
+TERMINAL.puts_header "Annotating code"
+
+run "bundle exec chusaku"
+run "bundle exec annotate"
+
+TERMINAL.puts_header "Commiting code annotations to git"
+
+git add: "-A ."
+git commit: "-n -m 'Set up Ruby code annotation'"

--- a/variants/code-annotation/template.rb
+++ b/variants/code-annotation/template.rb
@@ -17,6 +17,8 @@ run "bundle install"
 # adds a rake task which causes annotate to auto-run on every migration
 run "bundle exec rails generate annotate:install"
 
+run "bundle exec rubocop -A lib/tasks/auto_annotate_models.rake"
+
 TERMINAL.puts_header "Annotating code"
 
 run "bundle exec chusaku"

--- a/variants/github_actions_ci/workflows/ci.yml
+++ b/variants/github_actions_ci/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - name: Check Run Ruby model annotations
+        run: bundle exec annotate --frozen
+      - name: Check Ruby controller annotations
+        run: bundle exec chusaku --exit-with-error-on-annotation
       - run: bundle exec rubocop
       - run: bundle exec brakeman --run-all-checks --exit-on-warn --format plain .
       - run: bundle exec bundle audit --update


### PR DESCRIPTION
I have worked on a number of projects which included these gems and the teams (including myself) have enjoyed having the annotations. The model annotations are particularly handy if you are unfamililar with the codebase.

This change:

* Install and run `chusaku` to annotate each controller action with a comment detailing the route which targets that action.
* Install and run `annotate` to annotate models, fixtures with the schema details of the model. `annotate` runs automatically after migrations.
* Setup CI to check that both `chusaku` and `annotate` annotations are up to date.

Closes #366