### PR TITLE
fix: only apply one capistrano variant regardless of what configs are set

### DIFF
--- a/ackama_rails_template.config.yml
+++ b/ackama_rails_template.config.yml
@@ -20,11 +20,12 @@ apply_variant_devise: false
 apply_variant_sidekiq: false
 apply_variant_bootstrap: false
 
-# Generates code to setup a fairly generic Capistrano install
-apply_variant_deploy_with_capistrano: false
-
 # Copy in some examples for Github Actions CI
 apply_variant_github_actions_ci: true
+
+# Generates code to set up a fairly generic Capistrano install - this is not required
+# if you're using the Ackama-specific variant
+apply_variant_deploy_with_capistrano: false
 
 # Generates Capistrano code specific to how Ackama likes to deploy
 # and manage EC2 instances.

--- a/template.rb
+++ b/template.rb
@@ -148,8 +148,12 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
     apply "variants/sidekiq/template.rb" if TEMPLATE_CONFIG.apply_variant_sidekiq?
 
     apply "variants/github_actions_ci/template.rb" if TEMPLATE_CONFIG.apply_variant_github_actions_ci?
-    apply "variants/deploy_with_capistrano/template.rb" if TEMPLATE_CONFIG.apply_variant_deploy_with_capistrano?
-    apply "variants/deploy_with_ackama_ec2_capistrano/template.rb" if TEMPLATE_CONFIG.apply_variant_deploy_with_ackama_ec2_capistrano?
+
+    if TEMPLATE_CONFIG.apply_variant_deploy_with_ackama_ec2_capistrano?
+      apply "variants/deploy_with_ackama_ec2_capistrano/template.rb"
+    elsif TEMPLATE_CONFIG.apply_variant_deploy_with_capistrano?
+      apply "variants/deploy_with_capistrano/template.rb"
+    end
 
     binstubs = %w[
       brakeman bundler bundler-audit rubocop


### PR DESCRIPTION
It's easy to think that if you're wanting to use our Ackama cap setup you should enable both flags, but that'll result in a weird smashup between two independent variants.

While we could try and handle this with documentation, I think it's better UX if we only respect the "most specific" cap variant that is enabled.