### PR TITLE
Use correct configuration key so that the lockable strategy is activated

### DIFF
--- a/variants/devise/template.rb
+++ b/variants/devise/template.rb
@@ -77,7 +77,7 @@ gsub_file "config/initializers/devise.rb",
 
 gsub_file "config/initializers/devise.rb",
           /  # config.unlock_strategy = .+/,
-          "  config.lock_strategy = :email"
+          "  config.unlock_strategy = :email"
 
 gsub_file "config/initializers/devise.rb",
           /  # config.maximum_attempts = .+/,


### PR DESCRIPTION
This change modifies `lock_strategy` to `unlock_strategy`, since setting the lock strategy to `:email` instead of failed_attempts is not rejected, but causes the check in https://github.com/heartcombo/devise/blob/6d32d2447cc0f3739d9732246b5a5bde98d9e032/lib/devise/models/lockable.rb#L103 to return false, skipping any enforcement of account locking.