### PR TITLE
Use OkComputer to find git SHA of current deployment

### DIFF
--- a/variants/backend-base/app/views/layouts/application.html.erb.tt
+++ b/variants/backend-base/app/views/layouts/application.html.erb.tt
@@ -9,7 +9,7 @@
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 
-    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> (<%%= l(Rails.application.config.version_time) %>) -->
+    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> -->
 
     <%%# CSS should go closest to the top of the document as possible. %>
     <%%= stylesheet_link_tag("application", media: "all", "data-turbolinks-track": "reload") %>

--- a/variants/backend-base/config/initializers/version.rb
+++ b/variants/backend-base/config/initializers/version.rb
@@ -1,12 +1,6 @@
 Rails.application.config.version = begin
-  `git describe --always --tag 2> /dev/null`.chomp
+  # checks ENV["SHA"] and the "./REVISION" file
+  OkComputer::AppVersionCheck.new.version
 rescue StandardError
   "N/A"
-end
-
-Rails.application.config.version_time = begin
-  time = Time.zone.parse(`git log -1 --format="%ad" --date=iso 2> /dev/null`)
-  time || Time.zone.now
-rescue StandardError
-  Time.zone.now
 end


### PR DESCRIPTION
Replace shelling out to git (which only works in some environments) with the OkComputer check which supports checking more environments:

* The `REVISION` file created by Capistrano
* The `ENV["SHA"]` variable set by platforms like Heroku

This change also removes `Rails.application.config.version_time` because there is no way to get this information in a cross-platform way.

Closes #382