### PR TITLE
Prevent embedding the app as iframe by default

### DIFF
--- a/variants/backend-base/config/application.rb
+++ b/variants/backend-base/config/application.rb
@@ -16,6 +16,6 @@ insert_into_file "config/application.rb", before: /^  end/ do
 
     config.middleware.insert_before Rack::Sendfile, HttpBasicAuth
     config.action_dispatch.default_headers["Permissions-Policy"] = "interest-cohort=()"
-    config.action_dispatch.default_headers["X-Frame-Options"] = "deny"
+    config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
   RUBY
 end

--- a/variants/backend-base/config/application.rb
+++ b/variants/backend-base/config/application.rb
@@ -16,5 +16,6 @@ insert_into_file "config/application.rb", before: /^  end/ do
 
     config.middleware.insert_before Rack::Sendfile, HttpBasicAuth
     config.action_dispatch.default_headers["Permissions-Policy"] = "interest-cohort=()"
+    config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
   RUBY
 end

--- a/variants/backend-base/config/application.rb
+++ b/variants/backend-base/config/application.rb
@@ -16,6 +16,6 @@ insert_into_file "config/application.rb", before: /^  end/ do
 
     config.middleware.insert_before Rack::Sendfile, HttpBasicAuth
     config.action_dispatch.default_headers["Permissions-Policy"] = "interest-cohort=()"
-    config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
+    config.action_dispatch.default_headers["X-Frame-Options"] = "deny"
   RUBY
 end


### PR DESCRIPTION
Set `X-Frame-Options`  to the more secure `deny` value. Allowing our site to be embedded in an iframe is not something we want to support by default.

Closes #386