### PR TITLE
Issue 336 rake tasks

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -82,7 +82,6 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
 
   template "variants/backend-base/Gemfile.tt", "Gemfile", force: true
 
-  template "variants/backend-base/README.md.tt", "README.md", force: true
   remove_file "README.rdoc"
 
   template "variants/backend-base/example.env.tt", "example.env"
@@ -186,6 +185,10 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
     # We apply code annotation **after** all the other variants which might
     # generate routes and models
     apply "variants/code-annotation/template.rb"
+
+    # Run the README template at the end because it introspects the app to
+    # discover rake tasks etc.
+    template "variants/backend-base/README.md.tt", "README.md", force: true
   end
 end
 

--- a/template.rb
+++ b/template.rb
@@ -82,8 +82,6 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
 
   template "variants/backend-base/Gemfile.tt", "Gemfile", force: true
 
-  remove_file "README.rdoc"
-
   template "variants/backend-base/example.env.tt", "example.env"
   template "variants/backend-base/example.env.tt", ".env"
   copy_file "variants/backend-base/editorconfig", ".editorconfig"

--- a/variants/backend-base/README.md.tt
+++ b/variants/backend-base/README.md.tt
@@ -187,8 +187,12 @@ are up to date.
 
 ### Rake tasks
 
-```
-bundle exec rake developer:do_stuff
+```bash
+# App tasks (useful in local development and deployed environments)
+<%= `./bin/rails -T |grep 'app:'` %>
+
+# Dev tasks (useful in local development only)
+<%= `./bin/rails -T |grep 'dev:'` %>
 ```
 
     TODO: Are there rake tasks new developers should know about? Document them here

--- a/variants/backend-base/lib/tasks/app.rake
+++ b/variants/backend-base/lib/tasks/app.rake
@@ -1,0 +1,23 @@
+##
+# The app namespace is for tasks which may be useful both in local development
+# and on deployed environments.
+#
+# If your task will be run in local development only you should choose the `dev`
+# namespace (see `dev.rake``)
+#
+namespace :app do
+  desc "Print (to STDOUT) count of records in DB for each ActiveRecord model"
+  task db_stats: :environment do
+    # Ensure all classes are loaded if we are in an environment which lazy
+    # loads them (e.g. development)
+    Rails.application.eager_load!
+
+    ApplicationRecord
+      .descendants
+      .map(&:to_s)
+      .sort
+      .each do |model_name|
+      puts "#{model_name}: #{model_name.constantize.count} records"
+    end
+  end
+end

--- a/variants/backend-base/lib/tasks/dev.rake
+++ b/variants/backend-base/lib/tasks/dev.rake
@@ -1,0 +1,11 @@
+##
+# The dev namespace is for tasks which are intended for local development only.
+#
+# If your task could be run in local development or a deployed environment you
+# should choose the `app` namespace (see `app.rake`)
+#
+namespace :dev do
+  # desc "Increase developer happiness"
+  # task example: :environment do
+  # end
+end

--- a/variants/backend-base/lib/template.rb
+++ b/variants/backend-base/lib/template.rb
@@ -1,1 +1,3 @@
 copy_file "variants/backend-base/lib/tasks/coverage.rake", "lib/tasks/coverage.rake"
+copy_file "variants/backend-base/lib/tasks/app.rake", "lib/tasks/app.rake"
+copy_file "variants/backend-base/lib/tasks/dev.rake", "lib/tasks/dev.rake"


### PR DESCRIPTION
Closes #336 

* Add the records counting rake task within the `app` namespace. Include a comment guiding devs on what should go in `app` namespace.
* Create an empty `dev` namespace with a comment guiding devs on what to put there
* Document the tasks in the `app` and `dev` namespaces in the README
* `rails new` does not generate a `README.rdoc` anymore so we don't need to remove it
