### PR TITLE
feat: use shallow clone when deploying with capistrano

### DIFF
--- a/variants/deploy_with_ackama_ec2_capistrano/template.rb
+++ b/variants/deploy_with_ackama_ec2_capistrano/template.rb
@@ -42,6 +42,7 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
 
   set :application, "TODO_set_app_name"
   set :repo_url, "#{TEMPLATE_CONFIG.git_repo_url.presence || "TODO_set_git_repo_url"}"
+  set :git_shallow_clone, 1
 
   set :bundle_config, {
     deployment: true,

--- a/variants/deploy_with_capistrano/template.rb
+++ b/variants/deploy_with_capistrano/template.rb
@@ -43,6 +43,7 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
 
   set :application, "TODO_set_app_name"
   set :repo_url, "#{TEMPLATE_CONFIG.git_repo_url.presence || "TODO_set_git_repo_url"}"
+  set :git_shallow_clone, 1
 
   set :bundle_config, {
     deployment: true,


### PR DESCRIPTION
Me and @eoinkelly spoke about this a few months back when we inherited a project that has a rather bloated git repo meaning that clones could take a good couple of minutes; I've since been trying this on another project without issue, and while we're probably talking saving a few seconds on average, it's still nice to speed up deployments.