### PR TITLE
Use SENTRY_CSP_HEADER_REPORT_ENDPOINT for CSP reporting to sentry

### DIFF
--- a/variants/backend-base/config/initializers/content_security_policy.rb
+++ b/variants/backend-base/config/initializers/content_security_policy.rb
@@ -104,7 +104,7 @@ Rails.application.config.content_security_policy do |policy|
   # https://docs.sentry.io/error-reporting/security-policy-reporting/ for
   # details
   #
-  # policy.report_uri "https://o250825.ingest.sentry.io/api/1409600/security/?sentry_key=SOMETHING"
+  # policy.report_uri ENV.fetch("SENTRY_CSP_HEADER_REPORT_ENDPOINT")
 end
 
 # ###############


### PR DESCRIPTION
We already define `SENTRY_CSP_HEADER_REPORT_ENDPOINT` in the env exemplar: https://github.com/ackama/rails-template/blob/cfaac59de38e4a9e4e41ce22762563e8e97d8b13/variants/backend-base/example.env.tt#L27

So this amends the commentary in `content_security_policy.rb` to match. Issue inspired by https://github.com/ackama/whats-on/pull/231#discussion_r1029951477