### PR TITLE
ci: harden workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,22 @@ on:
     # * is a special character in YAML so you have to quote this string
     # * At 05:00 UTC every Monday, run the latest commit on the default or base branch
     - cron:  '0 5 * * MON'
+
+# Restrict jobs in this workflow to only be allowed to read this repo by default.
+#
+# If you are wanting to introduce a job/tool that requires more permissions (such
+# as posting comments or commits to the repository), then you should grant just
+# that job the necessarily permissions by giving it a dedicated `permissions` block.
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".node-version"
@@ -80,6 +91,8 @@ jobs:
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Install NodeJS
         uses: actions/setup-node@v3

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -18,12 +18,23 @@ env:
   SIDEKIQ_WEB_USERNAME: admin
   SIDEKIQ_WEB_PASSWORD: password
   <% end %>
+
+# Restrict jobs in this workflow to only be allowed to read this repo by default.
+#
+# If you are wanting to introduce a job/tool that requires more permissions (such
+# as posting comments or commits to the repository), then you should grant just
+# that job the necessarily permissions by giving it a dedicated `permissions` block.
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   js_based_checks:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".node-version"
@@ -67,6 +78,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Install Required OS Packages
         run: sudo apt-get -yqq install libpq-dev
       - name: Set up Ruby (version given by .ruby-version)
@@ -98,6 +111,9 @@ jobs:
   #     - ruby_based_checks
   #     - js_based_checks
   #   uses: ./.github/workflows/deploy_to_ec2.yml
+  #   permissions:
+  #     id-token: write # to use OIDC (aws-actions/configure-aws-credentials)
+  #     contents: read # to fetch code (actions/checkout)
   #   with:
   #     environment: staging
   #     assume_role_arn: TODO # e.g. "arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>StagingGHARole"
@@ -111,6 +127,9 @@ jobs:
   #     - ruby_based_checks
   #     - js_based_checks
   #   uses: ./.github/workflows/deploy_to_ec2.yml
+  #   permissions:
+  #     id-token: write # to use OIDC (aws-actions/configure-aws-credentials)
+  #     contents: read # to fetch code (actions/checkout)
   #   with:
   #     environment: production
   #     assume_role_arn: TODO # e.g. "arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>ProductionGHARole"
@@ -129,6 +148,8 @@ jobs:
   #     - ruby_based_checks
   #     - js_based_checks
   #   uses: ./.github/workflows/deploy_to_heroku.yml
+  #   permissions:
+  #     contents: read # to fetch code (actions/checkout)
   #   secrets:
   #     heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
   #     heroku_email: ${{ secrets.HEROKU_EMAIL }}
@@ -140,6 +161,8 @@ jobs:
   #     - ruby_based_checks
   #     - js_based_checks
   #   uses: ./.github/workflows/deploy_to_heroku.yml
+  #   permissions:
+  #     contents: read # to fetch code (actions/checkout)
   #   secrets:
   #     heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
   #     heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/variants/github_actions_ci/workflows/deploy_to_ec2.yml
+++ b/variants/github_actions_ci/workflows/deploy_to_ec2.yml
@@ -31,18 +31,23 @@ on:
         required: true
       slack_webhook:
         required: false
+
+# These are the permissions required by this nested workflow to function.
+#
+# You should include a copy of this block next to any `uses:` of this workflow
+permissions:
+  id-token: write # to use OIDC (aws-actions/configure-aws-credentials)
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   deploy_to_ec2_via_oidc:
     name: Deploy to AWS EC2 with Capistrano, authenticated by Github OIDC
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
-    permissions:
-      # These permissions are needed to interact with GitHub's OIDC Token
-      # endpoint.
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/variants/github_actions_ci/workflows/deploy_to_heroku.yml
+++ b/variants/github_actions_ci/workflows/deploy_to_heroku.yml
@@ -26,12 +26,21 @@ on:
         required: true
       slack_webhook:
         required: false
+
+# These are the permissions required by this nested workflow to function.
+#
+# You should include a copy of this block next to any `uses:` of this workflow
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   deploy_to_heroku:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: true # required to push to heroku
       - name: Deploy to Heroku Staging
         uses: akhileshns/heroku-deploy@v3.8.9
         with:


### PR DESCRIPTION
This hardens our CI permissions to make it a bit harder to exploit, should something nasty manage to slip by - currently the most likely way this could happen is through external dependencies i.e. if someone crafts a package that is designed to act like a useful package until it detects it's in a GHA CI environment, after which it tries any number of bad things (which can include silently creating a new branch and committing a new GHA workflow and .... I'm going to leave it there), or if one of the GitHub Actions we're using gets compromised in a similar fashion; this also puts us in a good position if/when we have tighter permissions around who can do what on repos.

I have tested this on a project that is being moved from Heroku to AWS, so I'm pretty sure these permission changes for both deployment workflows are correct, but won't complain if people want to try it out on their projects first (I'll also be looking to apply it to existing projects).