### PR TITLE
fix: lock `yarn` to v1 via `engines`

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -205,7 +205,10 @@ end
 
 def build_engines_field
   node_version = File.read("./.node-version").strip
-  { node: "^#{node_version}" }
+  {
+    node: "^#{node_version}",
+    yarn: "^1.0.0"
+  }
 end
 
 def cleanup_package_json


### PR DESCRIPTION
This helps ensure services like Heroku don't automatically install `yarn` v2 due to a lack of constraint - we don't use v2 (aka yarn berry) because it is effectively a whole new CLI which was never compatible with Rails, and while Rails is moving on from being involved in JS our existing apps are all using v1 and we prefer `npm` anyway so if things get more relaxed in future that'd probably be our path anyway.