### PR TITLE
fix: ensure `user` and `deploy_to` are set, and `rbenv_path` is not set, in Ackama capistrano variant

### DIFF
--- a/variants/deploy_with_ackama_ec2_capistrano/template.rb
+++ b/variants/deploy_with_ackama_ec2_capistrano/template.rb
@@ -74,8 +74,6 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
   # Default value for default_env is {}
   set :default_env, path: "$HOME/.rbenv/shims:$HOME/bin:/snap/bin:$PATH"
 
-  set :rbenv_path, "$HOME/.rbenv"
-
   # Ackama deployments use Fullstaq. Other possible values: :system, :user
   set :rbenv_type, :fullstaq
 

--- a/variants/deploy_with_ackama_ec2_capistrano/template.rb
+++ b/variants/deploy_with_ackama_ec2_capistrano/template.rb
@@ -78,7 +78,6 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
   set :rbenv_type, :fullstaq
 
   set :rbenv_ruby, File.read(".ruby-version").strip
-  set :rbenv_prefix, "$HOME/.rbenv/bin/rbenv exec"
   set :rbenv_map_bins, %w[rake gem bundle ruby rails]
 
   namespace :deploy do

--- a/variants/deploy_with_ackama_ec2_capistrano/template.rb
+++ b/variants/deploy_with_ackama_ec2_capistrano/template.rb
@@ -38,9 +38,12 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
   require "dotenv/load"
   require "aws_ec2_environment"
 
+  set :user, "deploy"
   set :application, "TODO_set_app_name"
   set :repo_url, "#{TEMPLATE_CONFIG.git_repo_url.presence || "TODO_set_git_repo_url"}"
   set :git_shallow_clone, 1
+
+  set :deploy_to, "/home/\#{fetch(:user)}/\#{fetch(:application)}"
 
   set :bundle_config, {
     deployment: true,


### PR DESCRIPTION
For me having `rbenv_path` set with our setup causes `capistrano-rbenv` to error saying it can't find the version of Ruby, which I assume is that it mucks with the fact we're using fullstaq (because it's looking under the `.rbenv` path).

We also need to set the `deploy_to` path since the default is `/var/www` which is not our standard path, and might as well set `user` too.