### PR TITLE
Use db:prepare which schema:loads rather than migrating from scratch

### DIFF
--- a/variants/backend-base/bin/setup
+++ b/variants/backend-base/bin/setup
@@ -11,9 +11,7 @@ def setup!
     copy "config/secrets.example.yml"
     test_local_env_contains_required_keys
     run  "bin/rake tmp:create"
-    run  "bin/rake db:create:all"
-    run  "bin/rake db:migrate"
-    run  "bin/rake db:seed"
+    run  "bin/rake db:prepare"
   end
 end
 


### PR DESCRIPTION
But also runs migrations if necessary, and creates the db if necessary

This reduces unecessary changes to the schema file, and is a much more straightforward way to build a db structure