### PR TITLE
Enable rubocop-capybara which is included in rubocop-rspec gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -3,6 +3,7 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-capybara
 
 # Built-in config:
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml


### PR DESCRIPTION
We use Capybara all the time so this seems sensible. It also silences a warning from rubocop when you run it in the generated apps:

```
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-capybara

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```