### PR TITLE
fix: import required bootstrap stylesheet

### DIFF
--- a/variants/frontend-bootstrap/app/frontend/stylesheets/customized_bootstrap.scss
+++ b/variants/frontend-bootstrap/app/frontend/stylesheets/customized_bootstrap.scss
@@ -20,6 +20,7 @@ $warning: #fce16e;
 $alert: #ff7070;
 
 @import "bootstrap/scss/variables"; // required, must happen after setting variables
+@import "bootstrap/scss/variables-dark"; //required, must happen after setting variable
 @import "bootstrap/scss/maps"; // required, must happen after any map variable overrides
 
 // Bring in Bootstrap


### PR DESCRIPTION
v5.3.0 introduced this, or more specifically this has variables in it that are used by other parts of bootstrap so we have to import it