### PR TITLE
ci: make app name a bit clearner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           # Rails app so you'll run into issues if that constant shares a name
           # with a class provided by a gem. Basically, don't name your app
           # "react", "sidekiq" etc.
-          APP_NAME: ${{ matrix.variant.name }}demo
+          APP_NAME: ${{ matrix.variant.name }}-demo
           CONFIG_PATH:  ${{ matrix.variant.config_path }}
           SKIPS: ${{ matrix.variant.skips }}
           PGUSER: postgres


### PR DESCRIPTION
Makes it a bit less confusing when you're looking at error logs in CI that have the path i.e. `No such file or directory @ rb_sysopen - /home/runner/work/rails-template/rails-template/tmp/builds/ackama_ec2_capistranodemo/config/webpacker.yml (Errno::ENOENT)` since to me `ackama_ec2_capistranodemo` smells like a `path.join` type bug