### PR TITLE
fix: support `shakapacker` v7

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -109,7 +109,7 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
   apply "variants/backend-base/spec/template.rb"
 
   # The block passed to "after_bundle" seems to run after `bundle install`
-  # but also after `webpacker:install` and after Rails has initialized the git
+  # but also after `shakapacker:install` and after Rails has initialized the git
   # repo
   after_bundle do
     # Remove the `test/` directory because we always use RSpec which creates

--- a/variants/backend-base/bin/ci-run
+++ b/variants/backend-base/bin/ci-run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-bundle exec rails webpacker:compile
+bundle exec rails shakapacker:compile
 
 SCRIPT_DIR=`dirname "$0"`
 APP_DIR="${SCRIPT_DIR}/.."

--- a/variants/backend-base/config/template.rb
+++ b/variants/backend-base/config/template.rb
@@ -43,10 +43,10 @@ route <<-EO_ROUTES
   # accessibility and performance tests. You are encouraged to remove this hack
   # as soon as it is no longer needed.
   #
-  if defined?(Webpacker) && Rails.env.test?
-    # manifest paths depend on your webpacker config so we inspect it
-    manifest_path = Webpacker::Configuration
-      .new(root_path: Rails.root, config_path: Rails.root.join("config/webpacker.yml"), env: Rails.env)
+  if defined?(Shakapacker) && Rails.env.test?
+    # manifest paths depend on your shakapacker config so we inspect it
+    manifest_path = Shakapacker::Configuration
+      .new(root_path: Rails.root, config_path: Rails.root.join("config/shakapacker.yml"), env: Rails.env)
       .public_manifest_path
       .relative_path_from(Rails.root.join("public"))
       .to_s

--- a/variants/backend-base/docker-compose.yml
+++ b/variants/backend-base/docker-compose.yml
@@ -22,13 +22,13 @@ services:
     <<: *rails
     links:
       - db
-      - webpacker
+      - shakapacker
     environment:
-      WEBPACKER_DEV_SERVER_HOST: webpacker
+      WEBPACKER_DEV_SERVER_HOST: shakapacker
     ports:
       - "3000:3000"
     command: "bash -c 'rm -rf tmp/pid/server.pid && rails s --binding 0.0.0.0'"
-  webpacker:
+  shakapacker:
     <<: *rails
     command: "./bin/webpack-dev-server"
 volumes:

--- a/variants/frontend-base-typescript/types.d.ts
+++ b/variants/frontend-base-typescript/types.d.ts
@@ -2,7 +2,8 @@ declare module 'shakapacker' {
   import { Configuration } from 'webpack';
 
   export { merge } from 'webpack-merge';
-  export const webpackConfig: Configuration;
+  export const globalMutableWebpackConfig: Configuration;
+  export function generateWebpackConfig(): Configuration;
 }
 
 declare module 'shakapacker/package/babel/preset.js' {

--- a/variants/frontend-base/config/webpack/webpack.config.js
+++ b/variants/frontend-base/config/webpack/webpack.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { webpackConfig, merge } = require('shakapacker');
+const { generateWebpackConfig, merge } = require('shakapacker');
 const Dotenv = require('dotenv-webpack');
 
 const customConfig = {
@@ -14,4 +14,4 @@ const customConfig = {
 
 // See the shakacode/shakapacker README and docs directory for advice on customizing your webpackConfig.
 
-module.exports = merge(webpackConfig, customConfig);
+module.exports = merge(generateWebpackConfig(), customConfig);

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -14,9 +14,9 @@ remove_dir "app/assets/stylesheets"
 remove_dir "app/assets/images"
 
 # this will create a package.json for us
-run "rails webpacker:install"
+run "rails shakapacker:install"
 
-# this is added by webpacker:install, but we've already got one (with some extra tags)
+# this is added by shakapacker:install, but we've already got one (with some extra tags)
 # in our template, so remove theirs otherwise the app will error when rendering this
 gsub_file "app/views/layouts/application.html.erb",
           "    <%= javascript_pack_tag \"application\" %>\n",
@@ -30,17 +30,10 @@ run "mv app/frontend/application.js app/frontend/packs/application.js"
 
 copy_file "config/webpack/webpack.config.js", force: true
 
-gsub_file "config/webpacker.yml", "source_entry_path: /", "source_entry_path: packs", force: true
-gsub_file "config/webpacker.yml", "cache_path: tmp/webpacker", "cache_path: tmp/cache/webpacker", force: true
-gsub_file "config/webpacker.yml", "source_path: app/javascript", "source_path: app/frontend", force: true
-gsub_file "config/webpacker.yml", "ensure_consistent_versioning: false", "ensure_consistent_versioning: true", force: true
-
-# Yarn's integrity check command is quite buggy, to the point that yarn v2 removed it
-#
-# The integrity check option itself has been removed in webpacker v5.1 but we
-# currently pull in v4, so we just set it to false to be safe
-#
-gsub_file "config/webpacker.yml", "check_yarn_integrity: true", "check_yarn_integrity: false", force: true
+gsub_file "config/shakapacker.yml", "source_entry_path: /", "source_entry_path: packs", force: true
+gsub_file "config/shakapacker.yml", "cache_path: tmp/shakapacker", "cache_path: tmp/cache/shakapacker", force: true
+gsub_file "config/shakapacker.yml", "source_path: app/javascript", "source_path: app/frontend", force: true
+gsub_file "config/shakapacker.yml", "ensure_consistent_versioning: false", "ensure_consistent_versioning: true", force: true
 
 empty_directory_with_keep_file "app/frontend/images"
 copy_file "app/frontend/stylesheets/application.scss"

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -71,7 +71,7 @@ body_open_tag_with_img_example = <<~EO_IMG_EXAMPLE
         # An example of how to load an image via Webpacker. This image is in
         # app/frontend/images/example.png
       %>
-      <%= image_pack_tag "example.png", alt: "Example Image" %>
+      <%= image_pack_tag "images/example.png", alt: "Example Image" %>
 EO_IMG_EXAMPLE
 gsub_file "app/views/layouts/application.html.erb", "<body>", body_open_tag_with_img_example, force: true
 

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -68,7 +68,7 @@ copy_file "app/frontend/images/example.png"
 body_open_tag_with_img_example = <<~EO_IMG_EXAMPLE
   <body>
       <%
-        # An example of how to load an image via Webpacker. This image is in
+        # An example of how to load an image via shakapacker. This image is in
         # app/frontend/images/example.png
       %>
       <%= image_pack_tag "images/example.png", alt: "Example Image" %>

--- a/variants/frontend-react-typescript/types.d.ts
+++ b/variants/frontend-react-typescript/types.d.ts
@@ -2,7 +2,8 @@ declare module 'shakapacker' {
   import { Configuration } from 'webpack';
 
   export { merge } from 'webpack-merge';
-  export const webpackConfig: Configuration;
+  export const globalMutableWebpackConfig: Configuration;
+  export function generateWebpackConfig(): Configuration;
 }
 
 declare module 'shakapacker/package/babel/preset.js' {

--- a/variants/performance/spec/performance_helper.rb
+++ b/variants/performance/spec/performance_helper.rb
@@ -15,7 +15,7 @@ require "fileutils"
 RSpec.configure do |config|
   # Precompiling assets before running specs with js set to true not only helps
   # to speed things up slightly but also creates an environment that we can run
-  # performance specs against.  Without this webpacker doesn't zip the js packs
+  # performance specs against.  Without this shakapacker doesn't zip the js packs
   # and the performance specs show vastly different results to a live
   # environment.
   config.before(:suite) do


### PR DESCRIPTION
See https://github.com/shakacode/shakapacker/blob/master/docs/v7_upgrade.md - I havn't yet confirmed if we need to make any changes for the "Stop stripping top-level dirs for static assets" section.