### PR TITLE
fix: lock `prettier` to v2

### DIFF
--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -8,7 +8,7 @@ yarn_add_dev_dependencies %w[
   eslint-plugin-import
   eslint-plugin-prettier
   eslint-plugin-eslint-comments
-  prettier
+  prettier@^2.7.0
   prettier-config-ackama
   prettier-plugin-packagejson
 ]


### PR DESCRIPTION
v3 was released a couple of days ago, and among other things drops support for its sync API which means ESLint can't use it anymore - I expect the ecosystem to react, but as of right now we can't "just use v3".