### PR TITLE
fix: use latest prettier and lock `@typescipt-eslint` to v5

### DIFF
--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -22,7 +22,10 @@ types_packages = %w[
 ].map { |name| "@types/#{name}" }
 
 yarn_add_dependencies types_packages + %w[@babel/preset-typescript typescript]
-yarn_add_dev_dependencies %w[@typescript-eslint/parser @typescript-eslint/eslint-plugin]
+yarn_add_dev_dependencies %w[
+  @typescript-eslint/parser@5
+  @typescript-eslint/eslint-plugin@5
+]
 
 run "yarn install"
 

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -8,7 +8,7 @@ yarn_add_dev_dependencies %w[
   eslint-plugin-import
   eslint-plugin-prettier
   eslint-plugin-eslint-comments
-  prettier@^2.7.0
+  prettier
   prettier-config-ackama
   prettier-plugin-packagejson
 ]

--- a/variants/frontend-bootstrap-typescript/template.rb
+++ b/variants/frontend-bootstrap-typescript/template.rb
@@ -1,7 +1,10 @@
 source_paths.unshift(File.dirname(__FILE__))
 
 yarn_add_dependencies %w[@types/bootstrap]
-yarn_add_dev_dependencies %w[@typescript-eslint/parser @typescript-eslint/eslint-plugin]
+yarn_add_dev_dependencies %w[
+  @typescript-eslint/parser@5
+  @typescript-eslint/eslint-plugin@5
+]
 
 run "yarn install"
 


### PR DESCRIPTION
I had assumed that the new major of `eslint-plugin-prettier` would be compatible with both v2 and v3, but I was wrong - of course it got released _after_ I opened #442...

Similarly `@typescript-eslint` released v6 this week - for now I'm just locking us to v5 to move towards a green CI but expect to do the minor work required to support v6 later this month.