### PR TITLE
fix: change `Layout/FirstArrayElementIndentation` to be `consistent`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,23 @@ Style/SignalException:
   EnforcedStyle: only_raise
 
 # We think that:
+#   array = [
+#     :value
+#   ]
+#   and_in_a_method_call([
+#     :value
+#   ])
+# Looks better than:
+#   value = [
+#     :value
+#   ]
+#   but_in_a_method_call([
+#                          :its_like_this
+#                         ])
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+# We think that:
 #   hash = {
 #     key: :value
 #   }

--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -85,6 +85,23 @@ Style/SignalException:
   EnforcedStyle: only_raise
 
 # We think that:
+#   array = [
+#     :value
+#   ]
+#   and_in_a_method_call([
+#     :value
+#   ])
+# Looks better than:
+#   value = [
+#     :value
+#   ]
+#   but_in_a_method_call([
+#                          :its_like_this
+#                         ])
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+# We think that:
 #   hash = {
 #     key: :value
 #   }


### PR DESCRIPTION
This is the sister rule to `Layout/FirstHashElementIndentation` which we adjusted in #433 - I hadn't realised it was a thing, but I assume everyone agrees it makes sense to have them .. er.. consistent with each other 😅 