### PR TITLE
Run CI against latest stable Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: '3.2'
+          ruby-version: 'ruby'
 
       - name: Setup git for committing
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: '3.0'
+          ruby-version: '3.2'
 
       - name: Setup git for committing
         run: |

--- a/variants/accessibility/Gemfile.rb
+++ b/variants/accessibility/Gemfile.rb
@@ -1,4 +1,4 @@
-insert_into_file "Gemfile", after: /gem "webdrivers"\n/ do
+insert_into_file "Gemfile", after: /gem "selenium-webdriver"\n/ do
   <<~GEMS
 
     gem "lighthouse-matchers"

--- a/variants/backend-base/Gemfile.tt
+++ b/variants/backend-base/Gemfile.tt
@@ -64,6 +64,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers"
   gem "simplecov", require: false
 end


### PR DESCRIPTION
Rails 7.0 supports Ruby 3.2.x (latest stable Ruby) so it makes sense that we should run our CI against it rather than 3.0.x

Closes #444
Closes #453