### PR TITLE
refactor: don't install `@typescript-eslint` again in bootstrap typescript variant

### DIFF
--- a/variants/frontend-bootstrap-typescript/template.rb
+++ b/variants/frontend-bootstrap-typescript/template.rb
@@ -1,10 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
 yarn_add_dependencies %w[@types/bootstrap]
-yarn_add_dev_dependencies %w[
-  @typescript-eslint/parser@5
-  @typescript-eslint/eslint-plugin@5
-]
 
 run "yarn install"
 


### PR DESCRIPTION
The base typescript variant already installs it, so we don't have to as part of this variant.