### PR TITLE
docs: mention that postgres is required to run the generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ working directory if it exists. Otherwise you can specify a path using the
 [ackama_rails_template.config.yml](./ackama_rails_template.config.yml) is a
 documented configuration example that you can copy.
 
+You must also have Postgres running on port 5432.
+
 To generate a Rails application using this template, pass the `--template`
 option to `rails new`, like this:
 


### PR DESCRIPTION
I'm happy if someone wants to improve how this is explained around the rest of the doc so it's less of a "short random sentence", but at least now it is documented.