### PR TITLE
fix: don't include trailing whitespace or newlines in GitHub Actions workflow

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -14,10 +14,10 @@ env:
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
   RAILS_SECRET_KEY_BASE: any-value-works-here-in-ci-but-prod-should-be-created-with-bundle-exec-rails-secret
   MAIL_FROM: "changeme@example.com"
-  <% if TEMPLATE_CONFIG.apply_variant_sidekiq? %>
+  <%- if TEMPLATE_CONFIG.apply_variant_sidekiq? -%>
   SIDEKIQ_WEB_USERNAME: admin
   SIDEKIQ_WEB_PASSWORD: password
-  <% end %>
+  <%- end -%>
 
 # Restrict jobs in this workflow to only be allowed to read this repo by default.
 #
@@ -48,9 +48,9 @@ jobs:
           node-version-file: ".node-version"
           cache: "yarn"
       - run: yarn install --frozen-lockfile
-      <% if TEMPLATE_CONFIG.use_typescript? %>
+      <%- if TEMPLATE_CONFIG.use_typescript? -%>
       - run: yarn run typecheck
-      <% end %>
+      <%- end -%>
       - run: yarn run js-lint
       - run: yarn run format-check
   ruby_based_checks:


### PR DESCRIPTION
[Thor runs ERB with `trim_mode` set to `-`](https://github.com/rails/thor/blob/main/lib/thor/actions/file_manipulation.rb#L126C68-L126C82) which means that `<%-` and `-%>` are required to do whitespace trimming - this is different from Rails where whitespace trimming is automatically applied:

> When on a line that only contains whitespaces except for the tag, <% %> suppresses leading and trailing whitespace, including the trailing newline. <% %> and <%- -%> are the same.

<details>
<summary>comparisons of the difference when running through Thor given a snippet from our GitHub Actions workflow template</summary>

```
❯ cat -e my_file.yml
# condition false, without %- -%$
$
env:$
  RAILS_ENV: test$
  DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres$
  RAILS_SECRET_KEY_BASE: any-value-works-here-in-ci-but-prod-should-be-created-with-bundle-exec-rails-secret$
  MAIL_FROM: "changeme@example.com"$
  $
$
# Restrict jobs in this workflow to only be allowed to read this repo by default.$
#$
# If you are wanting to introduce a job/tool that requires more permissions (such$
# as posting comments or commits to the repository), then you should grant just$
# that job the necessarily permissions by giving it a dedicated `permissions` block.$
permissions:$
  contents: read # to fetch code (actions/checkout)$
$
# ----------------------------------------------------------------------------------------------------------$
# condition true, without %- -%$
$
env:$
  RAILS_ENV: test$
  DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres$
  RAILS_SECRET_KEY_BASE: any-value-works-here-in-ci-but-prod-should-be-created-with-bundle-exec-rails-secret$
  MAIL_FROM: "changeme@example.com"$
  $
  SIDEKIQ_WEB_USERNAME: admin$
  SIDEKIQ_WEB_PASSWORD: password$
  $
$
# Restrict jobs in this workflow to only be allowed to read this repo by default.$
#$
# If you are wanting to introduce a job/tool that requires more permissions (such$
# as posting comments or commits to the repository), then you should grant just$
# that job the necessarily permissions by giving it a dedicated `permissions` block.$
permissions:$
  contents: read # to fetch code (actions/checkout)$
$
# ----------------------------------------------------------------------------------------------------------$
# condition false, with %- -%$
$
env:$
  RAILS_ENV: test$
  DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres$
  RAILS_SECRET_KEY_BASE: any-value-works-here-in-ci-but-prod-should-be-created-with-bundle-exec-rails-secret$
  MAIL_FROM: "changeme@example.com"$
$
# Restrict jobs in this workflow to only be allowed to read this repo by default.$
#$
# If you are wanting to introduce a job/tool that requires more permissions (such$
# as posting comments or commits to the repository), then you should grant just$
# that job the necessarily permissions by giving it a dedicated `permissions` block.$
permissions:$
  contents: read # to fetch code (actions/checkout)$
$
# ----------------------------------------------------------------------------------------------------------$
# condition true, with %- -%$
$
env:$
  RAILS_ENV: test$
  DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres$
  RAILS_SECRET_KEY_BASE: any-value-works-here-in-ci-but-prod-should-be-created-with-bundle-exec-rails-secret$
  MAIL_FROM: "changeme@example.com"$
  SIDEKIQ_WEB_USERNAME: admin$
  SIDEKIQ_WEB_PASSWORD: password$
$
# Restrict jobs in this workflow to only be allowed to read this repo by default.$
#$
# If you are wanting to introduce a job/tool that requires more permissions (such$
# as posting comments or commits to the repository), then you should grant just$
# that job the necessarily permissions by giving it a dedicated `permissions` block.$
permissions:$
  contents: read # to fetch code (actions/checkout)$
```
</details>