### PR TITLE
fix: explicitly setup `node` and run `yarn install` before running specs

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -101,6 +101,11 @@ jobs:
       - run: bundle exec rubocop
       - run: bundle exec brakeman --run-all-checks --exit-on-warn --format plain .
       - run: bundle exec rails db:setup
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
       - run: bundle exec rspec spec --format progress
       - name: Archive spec outputs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Technically API-only apps won't need this but we pretty much never do those and this shouldn't error so at worse it'll just add a couple of seconds to CI.

Resolves #456