### PR TITLE
fix: ensure that frontend assets are installed before (pre)compiling

### DIFF
--- a/variants/backend-base/lib/tasks/assets.rake
+++ b/variants/backend-base/lib/tasks/assets.rake
@@ -1,0 +1,8 @@
+namespace :assets do
+  desc "Ensures that dependencies required to compile assets are installed"
+  task install_dependencies: :environment do
+    raise if File.exist?("yarn.lock") && !(system "yarn install --frozen-lockfile")
+  end
+end
+
+Rake::Task["assets:precompile"].enhance ["assets:install_dependencies"]


### PR DESCRIPTION
This was removed in Shakapacker v7 though our CI doesn't fail because we're already installing it before every command - but that does not happen for deployments.