### PR TITLE
feat: support setting and displaying the revision time for capistrano-based deployments

### DIFF
--- a/variants/backend-base/app/views/layouts/application.html.erb.tt
+++ b/variants/backend-base/app/views/layouts/application.html.erb.tt
@@ -9,7 +9,7 @@
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 
-    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> (<%%= Rails.application.config.version_time.iso8601 %>) -->
+    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> (<%%= Rails.application.config.version_time&.iso8601 || "Unknown" %>) -->
 
     <%%# CSS should go closest to the top of the document as possible. %>
     <%%= stylesheet_link_tag("application", media: "all", "data-turbolinks-track": "reload") %>

--- a/variants/backend-base/app/views/layouts/application.html.erb.tt
+++ b/variants/backend-base/app/views/layouts/application.html.erb.tt
@@ -9,7 +9,7 @@
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 
-    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> -->
+    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> (<%%= l(Rails.application.config.version_time) %>) -->
 
     <%%# CSS should go closest to the top of the document as possible. %>
     <%%= stylesheet_link_tag("application", media: "all", "data-turbolinks-track": "reload") %>

--- a/variants/backend-base/app/views/layouts/application.html.erb.tt
+++ b/variants/backend-base/app/views/layouts/application.html.erb.tt
@@ -9,7 +9,7 @@
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 
-    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> (<%%= l(Rails.application.config.version_time) %>) -->
+    <!-- <%= app_const_base.titleize %> <%%= Rails.application.config.version %> (<%%= Rails.application.config.version_time.iso8601 %>) -->
 
     <%%# CSS should go closest to the top of the document as possible. %>
     <%%= stylesheet_link_tag("application", media: "all", "data-turbolinks-track": "reload") %>

--- a/variants/backend-base/config/initializers/version.rb
+++ b/variants/backend-base/config/initializers/version.rb
@@ -14,7 +14,7 @@ Rails.application.config.version_time = begin
 
     File.read(path).chomp
   end
-  Time.zone.at(value.to_i)
+  Time.utc.at(value.to_i)
 rescue StandardError
   Time.zone.at(0)
 end

--- a/variants/backend-base/config/initializers/version.rb
+++ b/variants/backend-base/config/initializers/version.rb
@@ -4,3 +4,17 @@ Rails.application.config.version = begin
 rescue StandardError
   "N/A"
 end
+
+Rails.application.config.version_time = begin
+  value = ENV.fetch("SHA_TIME") do
+    # this file will be created by our capistrano deployments
+    path = Rails.root.join("REVISION_TIME")
+
+    raise StandardError unless File.exist?(path)
+
+    File.read(path).chomp
+  end
+  Time.zone.at(value.to_i)
+rescue StandardError
+  Time.zone.at(0)
+end

--- a/variants/backend-base/config/initializers/version.rb
+++ b/variants/backend-base/config/initializers/version.rb
@@ -16,5 +16,5 @@ Rails.application.config.version_time = begin
   end
   Time.utc.at(value.to_i)
 rescue StandardError
-  Time.zone.at(0)
+  nil
 end

--- a/variants/deploy_with_ackama_ec2_capistrano/template.rb
+++ b/variants/deploy_with_ackama_ec2_capistrano/template.rb
@@ -80,6 +80,20 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
   set :rbenv_ruby, File.read(".ruby-version").strip
   set :rbenv_map_bins, %w[rake gem bundle ruby rails]
 
+  namespace :git do
+    desc "Determine the commit time of the revision that will be deployed"
+    task :set_current_revision_time do
+      on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
+        within repo_path do
+          with fetch(:git_environmental_variables) do
+            # fetches the revision time of the latest commit for the environment branch as a unix timestamp
+            set :current_revision_time, capture(:git, "log -1 --pretty=format:\\"%ct\\" #\{fetch(:branch)}")
+          end
+        end
+      end
+    end
+  end
+
   namespace :deploy do
     desc "Restart application"
     task :restart do
@@ -111,6 +125,25 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
     end
 
     after :publishing, :restart
+
+    desc "Place a REVISION_TIME file with the current revision commit time in the current release path"
+    task set_current_revision_time: "git:set_current_revision_time" do
+      on release_roles(:all) do
+        within release_path do
+          execute :echo, ""#\{fetch(:current_revision_time)}" > REVISION_TIME"
+        end
+      end
+    end
+
+    task :set_previous_revision_time do
+      on release_roles(:all) do
+        target = release_path.join("REVISION_TIME")
+        set(:previous_revision_time, capture(:cat, target, "2>/dev/null")) if test "[ -f #\{target} ]"
+      end
+    end
+
+    after :set_current_revision, :set_current_revision_time
+    after :set_previous_revision, :set_previous_revision_time
   end
 
   namespace :dotenv do

--- a/variants/deploy_with_ackama_ec2_capistrano/template.rb
+++ b/variants/deploy_with_ackama_ec2_capistrano/template.rb
@@ -157,11 +157,20 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
   end
 
   namespace :debug do
-    desc "Check Capistrano's SSM connection to the servers"
+    desc "Check Capistrano's connection to the servers"
     task :check_connection do
       on roles(:app) do
         execute "whoami"
         execute "hostname"
+      end
+    end
+
+    desc "Check the current revision hash and commit time being run on each server"
+    task check_revision: ["git:set_current_revision", "git:set_current_revision_time"] do
+      on roles(:app) do
+        hash = fetch(:current_revision)
+        time = Time.at(fetch(:current_revision_time).to_i).utc
+        info "#\{host}: running revision #\{hash}, committed at #\{time}"
       end
     end
   end

--- a/variants/deploy_with_capistrano/template.rb
+++ b/variants/deploy_with_capistrano/template.rb
@@ -144,6 +144,25 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
     after :set_previous_revision, :set_previous_revision_time
   end
 
+  namespace :debug do
+    desc "Check Capistrano's connection to the servers"
+    task :check_connection do
+      on roles(:app) do
+        execute "whoami"
+        execute "hostname"
+      end
+    end
+
+    desc "Check the current revision hash and commit time being run on each server"
+    task check_revision: ["git:set_current_revision", "git:set_current_revision_time"] do
+      on roles(:app) do
+        hash = fetch(:current_revision)
+        time = Time.at(fetch(:current_revision_time).to_i).utc
+        info "#\{host}: running revision #\{hash}, committed at #\{time}"
+      end
+    end
+  end
+
 EO_RUBY
 
 gsub_file("config/deploy.rb", old_generated_cap_config_snippet, new_ackama_cap_config_snippet)

--- a/variants/deploy_with_capistrano/template.rb
+++ b/variants/deploy_with_capistrano/template.rb
@@ -78,6 +78,20 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
   set :rbenv_prefix, "$HOME/.rbenv/bin/rbenv exec"
   set :rbenv_map_bins, %w[rake gem bundle ruby rails]
 
+  namespace :git do
+    desc "Determine the commit time of the revision that will be deployed"
+    task :set_current_revision_time do
+      on release_roles(:all), in: :groups, limit: fetch(:git_max_concurrent_connections), wait: fetch(:git_wait_interval) do
+        within repo_path do
+          with fetch(:git_environmental_variables) do
+            # fetches the revision time of the latest commit for the environment branch as a unix timestamp
+            set :current_revision_time, capture(:git, "log -1 --pretty=format:\\"%ct\\" #\{fetch(:branch)}")
+          end
+        end
+      end
+    end
+  end
+
   namespace :deploy do
     desc "Restart application"
     task :restart do
@@ -109,6 +123,25 @@ new_ackama_cap_config_snippet = <<~EO_RUBY
     end
 
     after :publishing, :restart
+
+    desc "Place a REVISION_TIME file with the current revision commit time in the current release path"
+    task set_current_revision_time: "git:set_current_revision_time" do
+      on release_roles(:all) do
+        within release_path do
+          execute :echo, ""#\{fetch(:current_revision_time)}" > REVISION_TIME"
+        end
+      end
+    end
+
+    task :set_previous_revision_time do
+      on release_roles(:all) do
+        target = release_path.join("REVISION_TIME")
+        set(:previous_revision_time, capture(:cat, target, "2>/dev/null")) if test "[ -f #\{target} ]"
+      end
+    end
+
+    after :set_current_revision, :set_current_revision_time
+    after :set_previous_revision, :set_previous_revision_time
   end
 
 EO_RUBY


### PR DESCRIPTION
This is something I explored due to a requirement for a particular application to have a version identifier in its admin panel even though we do continuous deployments; for that app there'll be additional work to display `version_time` on the actual page, but I think the underlying feature is useful since `version` (aka the commit sha) is only meaningful if you either note the version over time (in which case you can know if it changes) or if you have access to the source code.

I'm opening this as a draft for now because this is literally the first time I'm sharing the implementation so maybe its completely broken or concerning, but hopefully not 🙂

I have confirmed this works using an example site:

<img width="577" alt="image" src="https://github.com/ackama/rails-template/assets/3151613/04593baa-b91f-4f6f-997f-8b476d58f2a5">
