### PR TITLE
feat: switch to using `package_json` for interacting with `package.json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
       # how many fail)
       fail-fast: false
       matrix:
+        js_package_manager:
+          - name: npm
+            installer: npm
+          - name: yarn_classic
+            installer: yarn
+          - name: pnpm
+            installer: pnpm
         variant:
           - name: defaults
             config_path: 'ackama_rails_template.config.yml'
@@ -142,8 +149,11 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v4
         with:
-          cache: 'yarn'
+          cache: '${{ matrix.js_package_manager.installer }}'
           node-version-file: '.node-version'
+
+      - name: install package manager
+        run: npm i -g ${{ matrix.js_package_manager.installer }}
 
       # We don't cache gems or JS packages because we are actually testing how
       # installation and setup works in this project so, while caching would
@@ -173,4 +183,5 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
           PGHOST: localhost
+          PACKAGE_JSON_FALLBACK_MANAGER: ${{ matrix.js_package_manager.name }}
         run: ./ci/bin/build-and-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v4
         with:
-          cache: '${{ matrix.js_package_manager.installer }}'
           node-version-file: '.node-version'
 
       - name: install package manager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ concurrency:
 # should be granted per job as needed using a dedicated `permissions` block
 permissions: {}
 
+env:
+  # reduces noise from npm install
+  DISABLE_OPENCOLLECTIVE: true
+  OPEN_SOURCE_CONTRIBUTOR: true
+  NPM_CONFIG_FUND: false
+  NPM_CONFIG_AUDIT: false
+
 jobs:
   audit_dependencies:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           persist-credentials: false
       - name: Audit dependencies for security vulnerabilities
         uses: g-rath/check-with-osv-detector@main
+        with:
+          osv-detector-version: 0.13.0
   test:
     permissions:
       contents: read
@@ -149,6 +151,8 @@ jobs:
       # this ensures that osv-detector is available for running bin/ci-run
       - name: Check dependencies for vulnerabilities (and setup osv-detector)
         uses: g-rath/check-with-osv-detector@main
+        with:
+          osv-detector-version: 0.13.0
 
       # this ensures that actionlint is available for running bin/ci-run
       - name: Setup ActionLint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
         js_package_manager:
           - name: npm
             installer: npm
+          - name: yarn_berry
+            installer: yarn
+            linker: pnp
+          - name: yarn_berry
+            installer: yarn
+            linker: node-modules
+          - name: yarn_berry
+            installer: yarn
+            linker: pnpm
           - name: yarn_classic
             installer: yarn
           - name: pnpm
@@ -186,4 +195,6 @@ jobs:
           PGPASSWORD: postgres
           PGHOST: localhost
           PACKAGE_JSON_FALLBACK_MANAGER: ${{ matrix.js_package_manager.name }}
+          PACKAGE_JSON_YARN_BERRY_LINKER:
+            ${{ matrix.js_package_manager.linker }}
         run: ./ci/bin/build-and-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,9 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
 
+      # prettier-ignore
+      - run: ./ci/bin/create-fake-js-package-managers ${{ matrix.js_package_manager.installer }}
+
       - name: Run CI script
         env:
           # Remember that your app name becomes a top-level constant in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
             installer: yarn
           - name: pnpm
             installer: pnpm
+          - name: bun
+            installer: bun
         variant:
           - name: defaults
             config_path: 'ackama_rails_template.config.yml'

--- a/ci/bin/create-fake-js-package-managers
+++ b/ci/bin/create-fake-js-package-managers
@@ -30,7 +30,7 @@ elsif system("direnv --version > /dev/null 2>&1")
   system("direnv allow")
 end
 
-managers = %w[npm yarn pnpm]
+managers = %w[npm yarn pnpm bun]
 manager_in_use = ARGV[0] || ""
 
 if manager_in_use.empty?

--- a/ci/bin/create-fake-js-package-managers
+++ b/ci/bin/create-fake-js-package-managers
@@ -4,22 +4,49 @@
 # directory for GitHub Actions, _excluding_ the one passed in as an
 # argument in order to assert that only that package manager is used
 
+require "fileutils"
 require "tmpdir"
 
 # setup the bin directory we want to use
-bin_dir = Dir.mktmpdir("rails-template-")
+bin_dir = "tmp/fake-bin"
 
 if ENV["GITHUB_ACTIONS"]
+  bin_dir = Dir.mktmpdir("rails-template-")
+
   puts "adding #{bin_dir} to GITHUB_PATH..."
+
   File.write(ENV.fetch("GITHUB_PATH"), "#{bin_dir}\n", mode: "a+")
+elsif system("direnv --version > /dev/null 2>&1")
+  envrc_content = "PATH_add #{bin_dir}\n"
+
+  if File.exist?(".envrc") && File.read(".envrc").include?(envrc_content)
+    puts "'#{envrc_content.strip}' already exists in .envrc"
+  else
+    File.write(".envrc", envrc_content, mode: "a")
+    puts "Added '#{envrc_content.strip}' to .envrc"
+  end
+
+  # ensure the .envrc is allowed
+  system("direnv allow")
 end
 
 managers = %w[npm yarn pnpm]
-manager_in_use = ARGV[0]
+manager_in_use = ARGV[0] || ""
+
+if manager_in_use.empty?
+  manager_in_use = ENV.fetch("PACKAGE_JSON_FALLBACK_MANAGER", "")
+                      .delete_suffix("_berry")
+                      .delete_suffix("_classic")
+end
 
 Dir.chdir(bin_dir) do
   managers.each do |manager|
-    next if manager == manager_in_use
+    if manager == manager_in_use
+      # ensure that the manager is not stubbed in case we've changed managers
+      FileUtils.rm_f(manager)
+
+      next
+    end
 
     puts "creating #{bin_dir}/#{manager}..."
     File.write(

--- a/ci/bin/create-fake-js-package-managers
+++ b/ci/bin/create-fake-js-package-managers
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+# creates a set of fake JavaScript package managers in a temporary bin
+# directory for GitHub Actions, _excluding_ the one passed in as an
+# argument in order to assert that only that package manager is used
+
+require "tmpdir"
+
+# setup the bin directory we want to use
+bin_dir = Dir.mktmpdir("rails-template-")
+
+if ENV["GITHUB_ACTIONS"]
+  puts "adding #{bin_dir} to GITHUB_PATH..."
+  File.write(ENV.fetch("GITHUB_PATH"), "#{bin_dir}\n", mode: "a+")
+end
+
+managers = %w[npm yarn pnpm]
+manager_in_use = ARGV[0]
+
+Dir.chdir(bin_dir) do
+  managers.each do |manager|
+    next if manager == manager_in_use
+
+    puts "creating #{bin_dir}/#{manager}..."
+    File.write(
+      manager,
+      <<~CONTENTS
+        #!/usr/bin/env node
+
+        throw new Error("(#{manager}) this is not the package manager you're looking for...");
+      CONTENTS
+    )
+    File.chmod(0o755, manager)
+  end
+end

--- a/template.rb
+++ b/template.rb
@@ -132,7 +132,6 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
   apply "variants/backend-base/bin/template.rb"
   apply "variants/backend-base/config/template.rb"
   apply "variants/backend-base/doc/template.rb"
-  apply "variants/backend-base/lib/template.rb"
   apply "variants/backend-base/public/template.rb"
   apply "variants/backend-base/spec/template.rb"
 
@@ -141,6 +140,10 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
   # repo
   after_bundle do # rubocop:disable Metrics/BlockLength
     require_package_json_gem
+
+    apply "variants/backend-base/lib/template.rb"
+
+    template "variants/backend-base/bin/setup.tt", "bin/setup", force: true
 
     # Remove the `test/` directory because we always use RSpec which creates
     # its own `spec/` directory

--- a/template.rb
+++ b/template.rb
@@ -293,7 +293,8 @@ def cleanup_package_json
     }
   end
 
-  run "npx -y sort-package-json"
+  # TODO: this doesn't work when using pnpm even though it shouldn't matter? anyway, replace with 'exec' support
+  # run "npx -y sort-package-json"
 
   # ensure the lockfile is up to date with any changes we've made to package.json
   package_json.manager.install

--- a/template.rb
+++ b/template.rb
@@ -166,11 +166,11 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
       apply "variants/frontend-bootstrap-typescript/template.rb" if TEMPLATE_CONFIG.apply_variant_bootstrap?
       apply "variants/frontend-react-typescript/template.rb" if TEMPLATE_CONFIG.apply_variant_react?
 
-      package_json.manager.run("typecheck")
+      package_json.manager.run!("typecheck")
     end
 
     # apply any js linting fixes after all frontend variants have run
-    package_json.manager.run("js-lint-fix")
+    package_json.manager.run!("js-lint-fix")
 
     create_initial_migration
 
@@ -251,7 +251,7 @@ def apply_readme_template
 end
 
 def apply_prettier_all_over
-  package_json.manager.run("format-fix")
+  package_json.manager.run!("format-fix")
 
   git commit: ". -m 'Run prettier one last time'"
 end
@@ -297,7 +297,7 @@ def cleanup_package_json
   # run "npx -y sort-package-json"
 
   # ensure the lockfile is up to date with any changes we've made to package.json
-  package_json.manager.install
+  package_json.manager.install!
 end
 
 # Adds the given <code>packages</code> as dependencies using <code>yarn add</code>
@@ -306,7 +306,7 @@ end
 def yarn_add_dependencies(packages)
   puts "adding #{packages.join(" ")} as dependencies"
 
-  package_json.manager.add(packages)
+  package_json.manager.add!(packages)
 end
 
 # Adds the given <code>packages</code> as devDependencies using <code>yarn add --dev</code>
@@ -315,7 +315,7 @@ end
 def yarn_add_dev_dependencies(packages)
   puts "adding #{packages.join(" ")} as dev dependencies"
 
-  package_json.manager.add(packages, type: :dev)
+  package_json.manager.add!(packages, type: :dev)
 end
 
 # Add this template directory to source_paths so that Thor actions like

--- a/template.rb
+++ b/template.rb
@@ -257,7 +257,7 @@ def apply_prettier_all_over
 end
 
 def package_json
-  @package_json ||= PackageJson.new(:yarn_classic)
+  @package_json ||= PackageJson.new
 end
 
 # Normalizes the constraints of the given hash of dependencies so that they

--- a/template.rb
+++ b/template.rb
@@ -92,6 +92,10 @@ end
 TEMPLATE_CONFIG = Config.new
 TERMINAL = Terminal.new
 
+# We need the major version of 'jest', '@types/jest', and 'ts-jest' to match
+# so we can only upgrade jest when there are compatible versions available
+JEST_MAJOR_VERSION = "29".freeze
+
 def require_package_json_gem
   require "bundler/inline"
 

--- a/variants/accessibility/spec/rails_helper.rb
+++ b/variants/accessibility/spec/rails_helper.rb
@@ -9,6 +9,6 @@ insert_into_file "spec/rails_helper.rb", after: /# Add other Chrome arguments he
   <<~OPTIONS
     # Lighthouse Matcher options
     options.add_argument("--remote-debugging-port=9222")
-    Lighthouse::Matchers.chrome_flags = %w[headless no-sandbox]
+    Lighthouse::Matchers.chrome_flags = %w[headless=new no-sandbox]
   OPTIONS
 end

--- a/variants/accessibility/spec/rails_helper.rb
+++ b/variants/accessibility/spec/rails_helper.rb
@@ -12,3 +12,11 @@ insert_into_file "spec/rails_helper.rb", after: /# Add other Chrome arguments he
     Lighthouse::Matchers.chrome_flags = %w[headless=new no-sandbox]
   OPTIONS
 end
+
+if File.exist?(".yarnrc.yml")
+  insert_into_file "spec/rails_helper.rb", after: /# Lighthouse Matcher options\n/ do
+    <<~OPTIONS
+      Lighthouse::Matchers.lighthouse_cli = "yarn run lighthouse"
+    OPTIONS
+  end
+end

--- a/variants/backend-base/bin/setup.tt
+++ b/variants/backend-base/bin/setup.tt
@@ -5,7 +5,7 @@ def setup!
     test "ruby -v" => ruby_version
     run  "gem install bundler --no-document --conservative"
     run  "bundle install"
-    run  "yarn install" if File.exist?("yarn.lock")
+    run  "<%= package_json.manager.native_install_command.join(" ") %>" if File.exist?("package.json")
     run  "bundle exec overcommit --install" unless ENV["SKIP_OVERCOMMIT"] || ENV["CI"]
     copy "example.env"
     test_local_env_contains_required_keys

--- a/variants/backend-base/lib/tasks/assets.rake.tt
+++ b/variants/backend-base/lib/tasks/assets.rake.tt
@@ -1,7 +1,7 @@
 namespace :assets do
   desc "Ensures that dependencies required to compile assets are installed"
   task install_dependencies: :environment do
-    raise if File.exist?("yarn.lock") && !(system "yarn install --frozen-lockfile")
+    raise if File.exist?("package.json") && !(system "<%= package_json.manager.native_install_command(frozen: true).join(" ") %>")
   end
 end
 

--- a/variants/backend-base/lib/template.rb
+++ b/variants/backend-base/lib/template.rb
@@ -1,4 +1,5 @@
 copy_file "variants/backend-base/lib/tasks/coverage.rake", "lib/tasks/coverage.rake"
-copy_file "variants/backend-base/lib/tasks/assets.rake", "lib/tasks/assets.rake"
 copy_file "variants/backend-base/lib/tasks/app.rake", "lib/tasks/app.rake"
 copy_file "variants/backend-base/lib/tasks/dev.rake", "lib/tasks/dev.rake"
+
+template "variants/backend-base/lib/tasks/assets.rake.tt", "lib/tasks/assets.rake", force: true

--- a/variants/backend-base/spec/rails_helper.rb
+++ b/variants/backend-base/spec/rails_helper.rb
@@ -41,7 +41,7 @@ Capybara.register_driver :chrome do |app|
   options.add_argument("--window-size=1920,1080")
 
   # Add other Chrome arguments here
-  options.add_argument("--headless") unless ENV["HEADFUL"]
+  options.add_argument("--headless=new") unless ENV["HEADFUL"]
 
   # Docker compatibility
   options.add_argument("--no-sandbox")

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -53,8 +53,12 @@ ts_load_images_chunk = <<~EO_TS_ENABLE_IMAGES
 EO_TS_ENABLE_IMAGES
 gsub_file!("app/frontend/packs/application.ts", js_load_images_chunk, ts_load_images_chunk, force: true)
 
-update_package_json do |package_json|
-  package_json["scripts"]["typecheck"] = "tsc -p . --noEmit"
+package_json.merge! do |pj|
+  {
+    "scripts" => pj.fetch("scripts", {}).merge({
+      "typecheck" => "tsc -p . --noEmit"
+    })
+  }
 end
 
 append_to_file "bin/ci-run" do

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -67,6 +67,6 @@ append_to_file "bin/ci-run" do
     echo "* ******************************************************"
     echo "* Running Typechecking"
     echo "* ******************************************************"
-    yarn run typecheck
+    #{package_json.manager.native_run_command("typecheck").join(" ")}
   TYPECHECK
 end

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -19,6 +19,7 @@ types_packages = %w[
   webpack-env
   eslint@8
   babel__core
+  node@18
 ].map { |name| "@types/#{name}" }
 
 yarn_add_dependencies types_packages + %w[@babel/preset-typescript typescript]

--- a/variants/frontend-base/babel.config.js
+++ b/variants/frontend-base/babel.config.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const defaultConfigFunc = require('shakapacker/package/babel/preset.js');
+
+/** @type {import('@babel/core').ConfigFunction} */
+const config = api => {
+  const resultConfig = defaultConfigFunc(api);
+
+  resultConfig.plugins = [...resultConfig.plugins];
+
+  return resultConfig;
+};
+
+module.exports = config;

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -36,7 +36,7 @@ append_to_file "bin/ci-run" do
     echo "* ******************************************************"
     echo "* Running JS linting"
     echo "* ******************************************************"
-    yarn run js-lint
+    #{package_json.manager.native_run_command("js-lint").join(" ")}
   ESLINT
 end
 
@@ -46,7 +46,7 @@ append_to_file "bin/ci-run" do
     echo "* ******************************************************"
     echo "* Running JS linting"
     echo "* ******************************************************"
-    yarn run format-check
+    #{package_json.manager.native_run_command("format-check").join(" ")}
   PRETTIER
 end
 
@@ -66,6 +66,6 @@ append_to_file "bin/ci-run" do
     echo "* ******************************************************"
     echo "* Running SCSS linting"
     echo "* ******************************************************"
-    yarn run scss-lint
+    #{package_json.manager.native_run_command("scss-lint").join(" ")}
   SASSLINT
 end

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -15,16 +15,18 @@ yarn_add_dev_dependencies %w[
 copy_file "variants/frontend-base/.eslintrc.js", ".eslintrc.js"
 template "variants/frontend-base/.prettierignore.tt", ".prettierignore"
 
-update_package_json do |package_json|
-  package_json["prettier"] = "prettier-config-ackama"
-  package_json["browserslist"] = ["defaults"]
-  package_json["scripts"] = {
-    "js-lint" => "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts,tsx,jsx",
-    "js-lint-fix" => "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts,tsx,jsx --fix",
-    "format-check" => "prettier --check .",
-    "format-fix" => "prettier --write .",
-    "scss-lint" => "stylelint '**/*.{css,scss}'",
-    "scss-lint-fix" => "stylelint '**/*.{css,scss}' --fix"
+package_json.merge! do |pj|
+  {
+    "prettier" => "prettier-config-ackama",
+    "browserslist" => ["defaults"],
+    "scripts" => pj.fetch("scripts", {}).merge({
+      "js-lint" => "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts,tsx,jsx",
+      "js-lint-fix" => "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts,tsx,jsx --fix",
+      "format-check" => "prettier --check .",
+      "format-fix" => "prettier --write .",
+      "scss-lint" => "stylelint '**/*.{css,scss}'",
+      "scss-lint-fix" => "stylelint '**/*.{css,scss}' --fix"
+    })
   }
 end
 

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -1,6 +1,8 @@
 # Javascript code linting and formatting
 # ######################################
 
+add_yarn_package_extension_dependency("eslint-plugin-prettier", "eslint-config-prettier")
+
 yarn_add_dev_dependencies %w[
   eslint@8
   eslint-config-ackama
@@ -12,6 +14,7 @@ yarn_add_dev_dependencies %w[
   prettier-config-ackama
   prettier-plugin-packagejson
 ]
+
 copy_file "variants/frontend-base/.eslintrc.js", ".eslintrc.js"
 template "variants/frontend-base/.prettierignore.tt", ".prettierignore"
 

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -27,6 +27,12 @@ gsub_file! "app/views/layouts/application.html.erb",
 # Configure app/frontend
 
 run "mv app/javascript app/frontend"
+
+copy_file "babel.config.js", force: true
+
+# we've replaced this with a babel.config.js
+package_json.delete!("babel")
+
 copy_file "config/webpack/webpack.config.js", force: true
 
 gsub_file! "config/shakapacker.yml", "cache_path: tmp/shakapacker", "cache_path: tmp/cache/shakapacker"

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -13,9 +13,8 @@ end
 remove_dir "app/assets/stylesheets"
 remove_dir "app/assets/images"
 
-# create a basic package.json which explicitly sets our preferred package manager
-# for external tooling; shakapacker:install will add a _lot_ more for us later
-File.write("./package.json", JSON.generate({ "packageManager" => "yarn@1.22.21" }))
+# ensure our preferred js package manager is specified before running external tooling
+package_json.record_package_manager!
 
 run "rails shakapacker:install"
 

--- a/variants/frontend-react-typescript/template.rb
+++ b/variants/frontend-react-typescript/template.rb
@@ -1,6 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-package_json.manager.remove(["prop-types"])
+package_json.manager.remove!(["prop-types"])
 yarn_add_dependencies %w[@types/react @types/react-dom]
 
 rename_js_file_to_ts "app/frontend/packs/server_rendering"

--- a/variants/frontend-react-typescript/template.rb
+++ b/variants/frontend-react-typescript/template.rb
@@ -1,6 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-run "yarn remove prop-types"
+package_json.manager.remove(["prop-types"])
 yarn_add_dependencies %w[@types/react @types/react-dom]
 
 rename_js_file_to_ts "app/frontend/packs/server_rendering"

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -73,7 +73,5 @@ append_to_file "app/views/home/index.html.erb" do
   ERB
 end
 
-update_package_json do |package_json|
-  # we've replaced this with a babel.config.js
-  package_json.delete "babel"
-end
+# we've replaced this with a babel.config.js
+package_json.delete!("babel")

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -7,6 +7,8 @@ run "bundle install"
 
 run "rails generate react:install"
 
+add_yarn_package_extension_dependency("@testing-library/user-event", "@testing-library/dom")
+
 # prefer importing from the more specific package for consistency
 gsub_file! "app/frontend/test/stimulus/controllers/add_class_controller.test.js",
            "'@testing-library/dom'",

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -2,6 +2,10 @@ source_paths.unshift(File.dirname(__FILE__))
 
 add_yarn_package_extension_dependency("@testing-library/jest-dom", "@types/aria-query")
 add_yarn_package_extension_dependency("ts-jest", "@jest/transform")
+add_yarn_package_extension_dependency("ts-jest", "@jest/types")
+add_yarn_package_extension_dependency("@jest/test-result", "jest-haste-map")
+add_yarn_package_extension_dependency("@jest/test-result", "jest-resolve")
+add_yarn_package_extension_dependency("jest-cli", "@types/yargs")
 
 yarn_add_dependencies ["@babel/plugin-transform-typescript"]
 yarn_add_dev_dependencies [

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -3,6 +3,7 @@ source_paths.unshift(File.dirname(__FILE__))
 add_yarn_package_extension_dependency("@testing-library/jest-dom", "@types/aria-query")
 add_yarn_package_extension_dependency("ts-jest", "@jest/transform")
 
+yarn_add_dependencies ["@babel/plugin-transform-typescript"]
 yarn_add_dev_dependencies [
   "@types/jest@#{JEST_MAJOR_VERSION}",
   "ts-jest@#{JEST_MAJOR_VERSION}",

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -1,13 +1,11 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-installed_jest_major_version = PackageJson.read("node_modules/jest").fetch("version").split(".").first
-
 add_yarn_package_extension_dependency("@testing-library/jest-dom", "@types/aria-query")
 add_yarn_package_extension_dependency("ts-jest", "@jest/transform")
 
 yarn_add_dev_dependencies [
-  "@types/jest@#{installed_jest_major_version}",
-  "ts-jest@#{installed_jest_major_version}",
+  "@types/jest@#{JEST_MAJOR_VERSION}",
+  "ts-jest@#{JEST_MAJOR_VERSION}",
   "ts-node"
 ]
 

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -2,6 +2,9 @@ source_paths.unshift(File.dirname(__FILE__))
 
 installed_jest_major_version = PackageJson.read("node_modules/jest").fetch("version").split(".").first
 
+add_yarn_package_extension_dependency("@testing-library/jest-dom", "@types/aria-query")
+add_yarn_package_extension_dependency("ts-jest", "@jest/transform")
+
 yarn_add_dev_dependencies [
   "@types/jest@#{installed_jest_major_version}",
   "ts-jest@#{installed_jest_major_version}",

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -1,6 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-installed_jest_major_version = JSON.parse(File.read("node_modules/jest/package.json")).fetch("version").split(".").first
+installed_jest_major_version = PackageJson.read("node_modules/jest").fetch("version").split(".").first
 
 yarn_add_dev_dependencies [
   "@types/jest@#{installed_jest_major_version}",
@@ -15,10 +15,8 @@ copy_file "jest.config.ts"
 
 copy_file "babel.config.js", force: true
 
-update_package_json do |package_json|
-  # we've replaced this with a babel.config.js
-  package_json.delete "babel"
-end
+# we've replaced this with a babel.config.js
+package_json.delete!("babel")
 
 remove_file "app/frontend/stimulus/controllers/hello_controller.js", force: true
 copy_file "app/frontend/stimulus/controllers/hello_controller.ts"

--- a/variants/frontend-stimulus/template.rb
+++ b/variants/frontend-stimulus/template.rb
@@ -79,6 +79,6 @@ append_to_file "bin/ci-run" do
     echo "* ******************************************************"
     echo "* Running JS tests"
     echo "* ******************************************************"
-    yarn run test --coverage
+    #{package_json.manager.native_run_command("test", ["--coverage"]).join(" ")}
   JEST
 end

--- a/variants/frontend-stimulus/template.rb
+++ b/variants/frontend-stimulus/template.rb
@@ -65,13 +65,13 @@ yarn_add_dev_dependencies %W[
 copy_file ".eslintrc.js", force: true
 copy_file "jest.config.js"
 
-update_package_json do |package_json|
-  package_json["scripts"] = package_json["scripts"].merge(
-    {
+package_json.merge! do |pj|
+  {
+    "scripts" => pj.fetch("scripts", {}).merge({
       "test" => "jest",
       "watch-tests" => "jest --watch"
-    }
-  )
+    })
+  }
 end
 
 append_to_file "bin/ci-run" do

--- a/variants/frontend-stimulus/template.rb
+++ b/variants/frontend-stimulus/template.rb
@@ -46,10 +46,6 @@ append_to_file "app/frontend/packs/application.js" do
   EO_JS_SETUP
 end
 
-# We need the major version of the 'jest', '@jest/types', 'ts-jest' packages to
-# match so we can only upgrade jest when there are compatible versions available
-jest_major_version = "29"
-
 yarn_add_dev_dependencies %W[
   @testing-library/dom
   @testing-library/jest-dom
@@ -59,7 +55,7 @@ yarn_add_dev_dependencies %W[
   eslint-plugin-jest-dom
   eslint-plugin-testing-library
   jest-environment-jsdom
-  jest@#{jest_major_version}
+  jest@#{JEST_MAJOR_VERSION}
 ]
 
 copy_file ".eslintrc.js", force: true

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -50,13 +50,13 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'yarn'
-      - run: yarn install --frozen-lockfile
+      - run: <%= package_json.manager.native_install_command(frozen: true).join(" ") %>
       <%- if TEMPLATE_CONFIG.use_typescript? -%>
-      - run: yarn run typecheck
+      - run: <%= package_json.manager.native_run_command("typecheck").join(" ") %>
       <%- end -%>
-      - run: yarn run js-lint
-      - run: yarn run format-check
-      - run: yarn run test --coverage
+      - run: <%= package_json.manager.native_run_command("js-lint").join(" ") %>
+      - run: <%= package_json.manager.native_run_command("format-check").join(" ") %>
+      - run: <%= package_json.manager.native_run_command("test", ["--coverage"]).join(" ") %>
   ruby_based_checks:
     permissions:
       contents: read
@@ -110,7 +110,7 @@ jobs:
         with:
           node-version-file: '.node-version'
           cache: 'yarn'
-      - run: yarn install --frozen-lockfile
+      - run: <%= package_json.manager.native_install_command(frozen: true).join(" ") %>
       - run: bundle exec rspec spec --format progress
       - name: Archive spec outputs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This allows us to support all of the major javascript package managers by relying on the [`package_json`](https://github.com/shakacode/package_json) gem to handle running and generating commands for a particular package manager.

Currently I'm making our template actually agnostic and have setup to test that is the case by running against the major package managers + Yarn PnP, though I expect after landing this we'll decide on a single package manager to use going forward and remove code that is needed for the other package managers.