### PR TITLE
fix: update `@testing-library/user-event` syntax for v14

### DIFF
--- a/variants/frontend-react-typescript/app/frontend/test/components/HelloWorld.spec.tsx
+++ b/variants/frontend-react-typescript/app/frontend/test/components/HelloWorld.spec.tsx
@@ -12,11 +12,13 @@ describe('HelloWorld', () => {
 
   describe('when the user types in a new greeting', () => {
     it('changes to render that one', async () => {
+      const user = userEvent.setup();
+
       const { container } = render(
         <HelloWorld initialGreeting="Hello Ackama" />
       );
 
-      await userEvent.type(
+      await user.type(
         screen.getByRole('textbox', {
           name: /change the greeting/iu
         }),
@@ -27,11 +29,13 @@ describe('HelloWorld', () => {
     });
 
     it('can be reset back to the initial greeting', async () => {
+      const user = userEvent.setup();
+
       const { container } = render(
         <HelloWorld initialGreeting="Hello Ackama" />
       );
 
-      await userEvent.type(
+      await user.type(
         screen.getByRole('textbox', {
           name: /change the greeting/iu
         }),
@@ -40,7 +44,7 @@ describe('HelloWorld', () => {
 
       expect(container).not.toHaveTextContent('Hello Ackama');
 
-      await userEvent.click(screen.getByText('Reset'));
+      await user.click(screen.getByText('Reset'));
 
       expect(container).toHaveTextContent('Hello Ackama');
     });

--- a/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
+++ b/variants/frontend-react/app/frontend/test/components/HelloWorld.spec.jsx
@@ -13,6 +13,7 @@ describe('HelloWorld', () => {
   describe('when the user types in a new greeting', () => {
     it('changes to render that one', async () => {
       const user = userEvent.setup();
+
       const { container } = render(
         <HelloWorld initialGreeting="Hello Ackama" />
       );


### PR DESCRIPTION
This was discovered because `@testing-library/eslint-plugin-testing-library` released a new major a few hours ago which enables [`no-await-sync-events`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-await-sync-events.md)