### PR TITLE
fix: install `@types/jest`

### DIFF
--- a/variants/frontend-react-typescript/template.rb
+++ b/variants/frontend-react-typescript/template.rb
@@ -5,6 +5,7 @@ installed_jest_major_version = JSON.parse(File.read("node_modules/jest/package.j
 run "yarn remove prop-types"
 yarn_add_dependencies %w[@types/react @types/react-dom]
 yarn_add_dev_dependencies [
+  "@types/jest@#{installed_jest_major_version}",
   "@jest/types@#{installed_jest_major_version}",
   "ts-jest@#{installed_jest_major_version}",
   "ts-node"


### PR DESCRIPTION
We should be explicitly listing `@types/jest` as a dependency