### PR TITLE
fix: import `@testing-library/jest-dom` matchers in their own setup script

### DIFF
--- a/variants/frontend-stimulus-typescript/jest.config.ts
+++ b/variants/frontend-stimulus-typescript/jest.config.ts
@@ -9,7 +9,7 @@ const config: Config.InitialOptions = {
 
   testPathIgnorePatterns: ['config/'],
   setupFilesAfterEnv: [
-    '@testing-library/jest-dom/extend-expect',
+    './app/frontend/test/setupJestDomMatchers.ts',
     './app/frontend/test/setupExpectEachTestHasAssertions.ts'
   ],
 

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -29,5 +29,6 @@ copy_file "app/frontend/stimulus/controllers/hello_controller.ts"
 remove_file "app/frontend/stimulus/controllers/add_class_controller.js", force: true
 copy_file "app/frontend/stimulus/controllers/add_class_controller.ts"
 
+rename_js_file_to_ts "app/frontend/test/setupJestDomMatchers"
 rename_js_file_to_ts "app/frontend/test/setupExpectEachTestHasAssertions"
 rename_js_file_to_ts "app/frontend/test/stimulus/controllers/add_class_controller.test"

--- a/variants/frontend-stimulus/app/frontend/test/setupJestDomMatchers.js
+++ b/variants/frontend-stimulus/app/frontend/test/setupJestDomMatchers.js
@@ -1,0 +1,2 @@
+// this makes the jest-dom matchers available on `expect`
+import '@testing-library/jest-dom';

--- a/variants/frontend-stimulus/jest.config.js
+++ b/variants/frontend-stimulus/jest.config.js
@@ -9,7 +9,7 @@ const config = {
 
   testPathIgnorePatterns: ['config/'],
   setupFilesAfterEnv: [
-    '@testing-library/jest-dom/extend-expect',
+    './app/frontend/test/setupJestDomMatchers.js',
     './app/frontend/test/setupExpectEachTestHasAssertions.js'
   ]
 };


### PR DESCRIPTION
I'm on the fence about switching to have just a single `setup.js|ts` file as then we might have to do more logic on adding to that without conflicting, but it might be fine as we're not really doing that much and I don't expect we'll have more to add in the future...

Still we can make that switch later - for now I just want to get CI back in the green.