### PR TITLE
fix: actually copy `assets.rake` tasks

### DIFF
--- a/variants/backend-base/lib/template.rb
+++ b/variants/backend-base/lib/template.rb
@@ -1,3 +1,4 @@
 copy_file "variants/backend-base/lib/tasks/coverage.rake", "lib/tasks/coverage.rake"
+copy_file "variants/backend-base/lib/tasks/assets.rake", "lib/tasks/assets.rake"
 copy_file "variants/backend-base/lib/tasks/app.rake", "lib/tasks/app.rake"
 copy_file "variants/backend-base/lib/tasks/dev.rake", "lib/tasks/dev.rake"


### PR DESCRIPTION
Missed in #460