### PR TITLE
fix: ensure that `--skip-javascript` is always enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,49 +56,35 @@ jobs:
         variant:
           - name: defaults
             config_path: "ackama_rails_template.config.yml"
-            skips: --skip-javascript
           - name: all
             config_path: "ci/configs/all.yml"
-            skips: --skip-javascript
           - name: all-typescript
             config_path: "ci/configs/all-typescript.yml"
-            skips: --skip-javascript
           - name: basic
             config_path: "ci/configs/basic.yml"
-            skips: --skip-javascript
           - name: basic-typescript
             config_path: "ci/configs/basic-typescript.yml"
-            skips: --skip-javascript
           - name: github_actions
             config_path: "ci/configs/github_actions.yml"
-            skips: --skip-javascript
           - name: react
             config_path: "ci/configs/react.yml"
-            skips: --skip-javascript
           - name: react-typescript
             config_path: "ci/configs/react-typescript.yml"
-            skips: --skip-javascript
           - name: sidekiq
             config_path: "ci/configs/sidekiq.yml"
-            skips: --skip-javascript
           - name: devise
             config_path: "ci/configs/devise.yml"
-            skips: --skip-javascript
           - name: basic_with_skips
             config_path: "ci/configs/basic.yml"
             skips: --skip-spring --skip-javascript
           - name: bootstrap
             config_path: "ci/configs/bootstrap.yml"
-            skips: --skip-javascript
           - name: bootstrap-typescript
             config_path: "ci/configs/bootstrap-typescript.yml"
-            skips: --skip-javascript
           - name: capistrano
             config_path: "ci/configs/deploy_with_capistrano.yml"
-            skips: --skip-javascript
           - name: ackama_ec2_capistrano
             config_path: "ci/configs/deploy_with_ackama_ec2_capistrano.yml"
-            skips: --skip-javascript
     services:
       db:
         image: postgres
@@ -155,7 +141,7 @@ jobs:
           # "react", "sidekiq" etc.
           APP_NAME: ${{ matrix.variant.name }}-demo
           CONFIG_PATH:  ${{ matrix.variant.config_path }}
-          SKIPS: ${{ matrix.variant.skips }}
+          SKIPS: "--skip-javascript ${{ matrix.variant.skips }}"
           PGUSER: postgres
           PGPASSWORD: postgres
           PGHOST: localhost

--- a/ci/bin/build-and-test
+++ b/ci/bin/build-and-test
@@ -15,7 +15,7 @@ config_path = if ENV.fetch("CONFIG_PATH", "") == ""
               end
 
 config_env_var = %Q(CONFIG_PATH="#{config_path}") if config_path
-skip_flags = ENV.fetch("SKIPS", "")
+skip_flags = ENV.fetch("SKIPS", "--skip-javascript")
 
 puts "=" * 80
 puts <<~EO_CONFIG_SUMMARY

--- a/template.rb
+++ b/template.rb
@@ -296,6 +296,7 @@ def assert_valid_options
     skip_git: false,
     skip_test_unit: true,
     skip_active_storage: false,
+    skip_javascript: true,
     edge: false
   }
   valid_options.each do |key, expected|


### PR DESCRIPTION
This is what we recommend since our template handles setting up JavaScript related bundling, but we don't enforce it nor do we do it by default in `ci/bin/build-and-test` meaning running locally Rails can try to install importmaps and other stuff.

I think at the least we should make `build-and-test` include `--skip-javascript` as the default for `SKIPS`, but we can also actually enforce that its provided; if we don't want to do that, then we should ensure that the template is tested _without_ the flag instead.