### PR TITLE
fix: use latest version of `@typescript-eslint`

### DIFF
--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -23,8 +23,8 @@ types_packages = %w[
 
 yarn_add_dependencies types_packages + %w[@babel/preset-typescript typescript]
 yarn_add_dev_dependencies %w[
-  @typescript-eslint/parser@5
-  @typescript-eslint/eslint-plugin@5
+  @typescript-eslint/parser
+  @typescript-eslint/eslint-plugin
 ]
 
 run "yarn install"


### PR DESCRIPTION
Our eslint config now requires `@typescript-eslint` v6

Resolves #481