### PR TITLE
fix: call utc on time correctly

### DIFF
--- a/variants/backend-base/config/initializers/version.rb
+++ b/variants/backend-base/config/initializers/version.rb
@@ -14,7 +14,7 @@ Rails.application.config.version_time = begin
 
     File.read(path).chomp
   end
-  Time.utc.at(value.to_i)
+  Time.zone.at(value.to_i).utc
 rescue StandardError
   nil
 end


### PR DESCRIPTION
`Time.utc` expects to be provided year, month, day, etc as arguments - instead we should be calling `utc` on the constructed time.