### PR TITLE
ci: install specific version of Rails

### DIFF
--- a/ci/bin/build-and-test
+++ b/ci/bin/build-and-test
@@ -33,7 +33,7 @@ puts "=" * 80
 raise "Missing config YML file" if config_path && !(File.exist?(config_path) && File.file?(config_path))
 
 puts "Installing latest rails gem"
-system "gem install rails --no-document"
+system "gem install rails -v '~> 7.0.3' --no-document"
 
 unless Dir.exist?(builds_path)
   puts "Creating #{builds_path}"

--- a/variants/backend-base/app/views/layouts/application.html.erb.tt
+++ b/variants/backend-base/app/views/layouts/application.html.erb.tt
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>
-      <%%= strip_tags(yield(:title)) + " – " if content_for?(:title) %>
+      <%%= strip_tags(yield(:title)) + " - " if content_for?(:title) %>
       <%= app_const_base.titleize %>
     </title>
 
@@ -15,7 +15,7 @@
     <%%= stylesheet_link_tag("application", media: "all", "data-turbolinks-track": "reload") %>
 
     <%%# JavaScript must be in head for Turbolinks to work. %>
-    <%%= javascript_pack_tag "application", "data-turbolinks-track": "reload", defer: true %>
+    <%%= javascript_pack_tag "application", "data-turbolinks-track": "reload", defer: true, nonce: true %>
 
     <%%= yield(:head) %>
 

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -25,9 +25,6 @@ gsub_file "app/views/layouts/application.html.erb",
 # Configure app/frontend
 
 run "mv app/javascript app/frontend"
-run "mkdir app/frontend/packs"
-run "mv app/frontend/application.js app/frontend/packs/application.js"
-
 copy_file "config/webpack/webpack.config.js", force: true
 
 gsub_file "config/shakapacker.yml", "source_entry_path: /", "source_entry_path: packs", force: true


### PR DESCRIPTION
[We lock the version of Rails](https://github.com/ackama/rails-template/blob/main/template.rb#L5) that can be used for the template but don't ensure that version is installed when running CI.

This seems to work fine in CI but locally even though the correct version of Rails gets reportedly installed by `gem` it still ends up trying to use a later version of Rails 😕