### PR TITLE
fix: return `nil` if revision time ends up being zero

### DIFF
--- a/variants/backend-base/config/initializers/version.rb
+++ b/variants/backend-base/config/initializers/version.rb
@@ -13,8 +13,13 @@ Rails.application.config.version_time = begin
     raise StandardError unless File.exist?(path)
 
     File.read(path).chomp
+  end.to_i
+
+  if value.zero?
+    nil
+  else
+    Time.zone.at(value).utc
   end
-  Time.zone.at(value.to_i).utc
 rescue StandardError
   nil
 end


### PR DESCRIPTION
`String#to_i` works by returning all the digits in a string up to the first non-digit that isn't `_` (they're treated as separators) or the end of the string - if no digits are found then zero is returned.

One of the feedback items on  #461 was that when we can't determine the revision time we should explicitly return `nil` instead of a `Time`; but the above logic of `String#to_i` means we can end up returning the start of the epoch which goes against that.

This changes our logic so that we explicitly return `nil` if we end up getting a zero, ensuring our "Unknown time" logic will be triggered.