### PR TITLE
refactor: always expect self closing tags for void elements in ERB

### DIFF
--- a/variants/backend-base/.erb-lint.yml
+++ b/variants/backend-base/.erb-lint.yml
@@ -16,6 +16,9 @@ linters:
     enabled: false
   NoJavascriptTagHelper:
     enabled: false
+  SelfClosingTag:
+    enabled: true
+    enforced_style: 'always'
   Rubocop:
     enabled: true
     rubocop_config:


### PR DESCRIPTION
This aligns with what Prettier enforces for normal HTML files and what JSX requires; while there is a very small cost in bytes it doesn't outweigh the benefit in being consistent across our stacks and code.

Resolves #509