### PR TITLE
ci: include workflow in concurrency group

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -6,8 +6,8 @@ on:
       - main
       - production
 concurrency:
-  # Pushing new changes to a branch will cancel any in-progress CI runs
-  group: ${{ github.ref }}
+  # Pushing new changes to a branch will cancel any in-progress CI runs of this workflow
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
   RAILS_ENV: test


### PR DESCRIPTION
This hasn't caused problems because we don't have multiple workflows in our standard Rails setup, but we hit it on other stacks where we do and there's no downside so might as well do this here as best practice