### PR TITLE
ci: use environments when deploying

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -138,6 +138,7 @@ jobs:
   #     contents: read # to fetch code (actions/checkout)
   #   with:
   #     environment: staging
+  #     environment_url: '<%= "https://#{TEMPLATE_CONFIG.staging_hostname}" %>'
   #     assume_role_arn: TODO # e.g. "arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>StagingGHARole"
   #     aws_region: ap-southeast-2 # Sydney
   #   secrets:
@@ -155,6 +156,7 @@ jobs:
   #     contents: read # to fetch code (actions/checkout)
   #   with:
   #     environment: production
+  #     environment_url: '<%= "https://#{TEMPLATE_CONFIG.production_hostname}" %>'
   #     assume_role_arn: TODO # e.g. "arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>ProductionGHARole"
   #     aws_region: ap-southeast-2 # Sydney
   #   secrets:
@@ -174,6 +176,9 @@ jobs:
   #   uses: ./.github/workflows/deploy_to_heroku.yml
   #   permissions:
   #     contents: read # to fetch code (actions/checkout)
+  #   with:
+  #     environment: staging
+  #     environment_url: '<%= "https://#{TEMPLATE_CONFIG.staging_hostname}" %>'
   #   secrets:
   #     heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
   #     heroku_email: ${{ secrets.HEROKU_EMAIL }}
@@ -188,6 +193,9 @@ jobs:
   #   uses: ./.github/workflows/deploy_to_heroku.yml
   #   permissions:
   #     contents: read # to fetch code (actions/checkout)
+  #   with:
+  #     environment: production
+  #     environment_url: '<%= "https://#{TEMPLATE_CONFIG.production_hostname}" %>'
   #   secrets:
   #     heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
   #     heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/variants/github_actions_ci/workflows/deploy_to_ec2.yml
+++ b/variants/github_actions_ci/workflows/deploy_to_ec2.yml
@@ -5,6 +5,9 @@ on:
       environment:
         type: string
         required: true
+      environment_url:
+        type: string
+        required: false
       assume_role_arn:
         type: string
         required: true
@@ -44,6 +47,9 @@ jobs:
     name: Deploy to AWS EC2 with Capistrano, authenticated by Github OIDC
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ inputs.environment_url }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/variants/github_actions_ci/workflows/deploy_to_ec2.yml
+++ b/variants/github_actions_ci/workflows/deploy_to_ec2.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           role-to-assume: ${{ inputs.assume_role_arn }}
           aws-region: ${{ inputs.aws_region }}
-      - name: Install SSH key for production
+      - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.ssh_private_key }}

--- a/variants/github_actions_ci/workflows/deploy_to_heroku.yml
+++ b/variants/github_actions_ci/workflows/deploy_to_heroku.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: true # required to push to heroku
-      - name: Deploy to Heroku Staging
+      - name: Deploy to Heroku
         uses: akhileshns/heroku-deploy@v3.8.9
         with:
           heroku_api_key: ${{ secrets.heroku_api_key }}

--- a/variants/github_actions_ci/workflows/deploy_to_heroku.yml
+++ b/variants/github_actions_ci/workflows/deploy_to_heroku.yml
@@ -2,6 +2,12 @@ name: deploy_to_heroku
 on:
   workflow_call:
     inputs:
+      environment:
+        type: string
+        required: true
+      environment_url:
+        type: string
+        required: false
       timeout_minutes:
         type: number
         required: false
@@ -37,6 +43,9 @@ jobs:
   deploy_to_heroku:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout_minutes }}
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ inputs.environment_url }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
[Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) have a number of advantages both in terms of security and UX.

Notably we are able to see a list of deployments to environments with a direct link to the environment URL if present:

<img width="943" alt="image" src="https://github.com/ackama/rails-template/assets/3151613/cf31b1c7-e95b-4eb3-a0eb-6ec6aadd4be5">

This is also accessible via API and there are dedicated webhook events for new deployments which are useful for internal automation; deployments to environments also can be restricted to specific branches and can have their own secrets and variables allowing us in future to further DRY up our workflows (I've not done that here because we're still in the process of just switching our existing workflows to using environments, and I don't want to do too much too fast).

Environments are also automatically created if they don't already exist the first time a deployment occurs meaning there are no additional setup steps required by this change.

Note that this does impact OIDC-based workflows as environments take priority over other refs so this will change the OIDC claim from e.g. `"ref:refs/heads/production"` to `environment:production` - this is actually a positive in the long-run as it means branch:env mapping is fully managed in the application codebase rather at the infrastructure level.