### PR TITLE
feat: run `actionlint` for GitHub Actions variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,20 @@ jobs:
         variant:
           - name: defaults
             config_path: 'ackama_rails_template.config.yml'
+            install_actionlint: 'yes'
           - name: all
             config_path: 'ci/configs/all.yml'
+            install_actionlint: 'yes'
           - name: all-typescript
             config_path: 'ci/configs/all-typescript.yml'
+            install_actionlint: 'yes'
           - name: basic
             config_path: 'ci/configs/basic.yml'
           - name: basic-typescript
             config_path: 'ci/configs/basic-typescript.yml'
           - name: github_actions
             config_path: 'ci/configs/github_actions.yml'
+            install_actionlint: 'yes'
           - name: react
             config_path: 'ci/configs/react.yml'
           - name: react-typescript
@@ -128,6 +132,13 @@ jobs:
       # this ensures that osv-detector is available for running bin/ci-run
       - name: Check dependencies for vulnerabilities (and setup osv-detector)
         uses: g-rath/check-with-osv-detector@main
+
+      # this ensures that actionlint is available for running bin/ci-run
+      - name: Setup ActionLint
+        if: matrix.variant.install_actionlint == 'yes'
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          sudo ln -s "$PWD/actionlint" /usr/local/bin/actionlint
 
       - name: Install NodeJS
         uses: actions/setup-node@v3

--- a/variants/github_actions_ci/template.rb
+++ b/variants/github_actions_ci/template.rb
@@ -1,3 +1,13 @@
 template "variants/github_actions_ci/workflows/ci.yml.tt", ".github/workflows/ci.yml"
 copy_file "variants/github_actions_ci/workflows/deploy_to_ec2.yml", ".github/workflows/deploy_to_ec2.yml"
 copy_file "variants/github_actions_ci/workflows/deploy_to_heroku.yml", ".github/workflows/deploy_to_heroku.yml"
+
+append_to_file "bin/ci-run" do
+  <<~ACTIONLINT
+
+    echo "* ******************************************************"
+    echo "* Running ActionLint"
+    echo "* ******************************************************"
+    actionlint
+  ACTIONLINT
+end


### PR DESCRIPTION
While rebasing #466 after #516 was landed I learned that I had actually mucked up my erb for the GitHub Actions workflow - this was only picked up because it was invalid YAML so Prettier errored.

To help avoid mistakes in future, this introduces running [`actionlint`](https://github.com/rhysd/actionlint) as part of our _template_ CI.

Since doing so means that `bin/ci-run` now includes a tool that isn't in our CI workflow, this PR can also be seen as the initial nudge towards a possible future with a very different approach to `bin/ci-run` (including not having it at all) that I've been wanting to bring up for discussion for a bit.