### PR TITLE
feat: improve example nav for devise

### DIFF
--- a/variants/devise/template.rb
+++ b/variants/devise/template.rb
@@ -114,23 +114,21 @@ TERMINAL.puts_header "Adding example devise links to the homepage"
 
 append_to_file "app/views/application/_header.html.erb" do
   <<~ERB
-    <nav>
-      <h1>Example devise nav</h1>
-      <ul>
-        <li><%= link_to "Home", root_path %></li>
-      </ul>
-    <% if current_user %>
-      <p>You are <strong>Signed in</strong></p>
-      <ul>
-        <li><%= link_to "Sign out", destroy_user_session_path, method: :delete %></li>
-      </ul>
-    <% else %>
-      <p>You are <strong>Not signed in</strong></p>
-      <ul>
-        <li><%= link_to "Sign in", new_user_session_path %></li>
-        <li><%= link_to "Sign up", new_user_registration_path %></li>
-      </ul>
-    <% end %>
+    <nav class="navbar navbar-expand-sm navbar-light bg-light">
+      <div class="container-fluid">
+        <h1>Example devise nav</h1>
+        <ul class="navbar-nav">
+          <li class="nav-item"><%= link_to "Home", root_path, class: "nav-link" %></li>
+          <% if current_user %>
+            <li class="navbar-text">You are <strong>Signed in</strong></li>
+            <li class="nav-item"><%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "nav-link" %></li>
+          <% else %>
+            <li class="navbar-text">You are <strong>Not signed in</strong></li>
+            <li class="nav-item"><%= link_to "Sign in", new_user_session_path, class: "nav-link" %></li>
+            <li class="nav-item"><%= link_to "Sign up", new_user_registration_path, class: "nav-link" %></li>
+          <% end %>
+        </ul>
+      </div>
     </nav>
   ERB
 end


### PR DESCRIPTION
This improves the default nav we generate by using bootstrap classes which in addition to just making it look nicer will hopefully be slightly more useful by having a working nav implemented since we expect to be using bootstrap as our standard for projects that require such styled frontends.

<img width="800" alt="image" src="https://github.com/ackama/rails-template/assets/3151613/62794fe6-0a15-4648-8a42-718183c9b9a8">

This degrades gracefully when bootstrap is not present too:

<img width="278" alt="image" src="https://github.com/ackama/rails-template/assets/3151613/eb726640-e399-491d-ac27-07c482a0ff72">

I initially considered making this based on if the bootstrap variant was enabled or adding a comment about it, but ultimately I don't think it'll be that confusing to have these css classes if bootstrap isn't being used.