### PR TITLE
fix: omit default brakeman flags

### DIFF
--- a/variants/backend-base/bin/ci-run
+++ b/variants/backend-base/bin/ci-run
@@ -21,7 +21,7 @@ osv-detector .
 echo "* ******************************************************"
 echo "* Running brakeman"
 echo "* ******************************************************"
-bundle exec brakeman --exit-on-warn --quiet --no-pager
+bundle exec brakeman --quiet --no-pager
 
 echo "* ******************************************************"
 echo "* Running all rspec specs"

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -103,7 +103,7 @@ jobs:
       - run: bundle exec rubocop
       - name: Run erb-lint to check HTML formatting and run Rubocop on Ruby within ERB
         run: bundle exec erblint .
-      - run: bundle exec brakeman --run-all-checks --exit-on-warn --format plain .
+      - run: bundle exec brakeman --run-all-checks .
       - run: bundle exec rails db:setup
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
These are the default [since v4.0.0](https://github.com/presidentbeef/brakeman/blob/main/CHANGES.md#400---2017-09-25).

The actual motivator for this is that it brings the line under 80 characters so Prettier is happier, but also really we should be using `config/brakeman.yml` for these settings to ensure all brakeman calls are consistent by default (I've not added that though because I have not seen evidence that brakeman is in the habit of changing its defaults often, so I don't think we need to worry)
