### PR TITLE
fix: use `click_on` rather than `click_link` and `click_button`

### DIFF
--- a/variants/devise/spec/system/user_reset_password_feature_spec.rb
+++ b/variants/devise/spec/system/user_reset_password_feature_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "Users can reset passwords" do
       end
 
       it "existing users can reset their passwords from the sign-in page" do
-        click_link "Forgot your password?"
+        click_on "Forgot your password?"
         fill_in "Email", with: email_of_existing_user
-        click_button "Send me reset password instructions"
+        click_on "Send me reset password instructions"
 
         # we expect to be redirected to the sign-in page ...
         expect(page).to have_current_path(new_user_session_path, ignore_query: true)
@@ -40,9 +40,9 @@ RSpec.describe "Users can reset passwords" do
 
     context "with unknown users" do
       it "unknown users get an error when they try to reset a password" do
-        click_link "Forgot your password?"
+        click_on "Forgot your password?"
         fill_in "Email", with: email_of_unknown_user
-        click_button "Send me reset password instructions"
+        click_on "Send me reset password instructions"
 
         # we expect to be redirected to the user sign-in page ...
         expect(page).to have_current_path(new_user_session_path, ignore_query: true)

--- a/variants/devise/spec/system/user_sign_in_feature_spec.rb
+++ b/variants/devise/spec/system/user_sign_in_feature_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "User sign-in" do
       # when we fill in the sign-in form
       fill_in "Email", with: email
       fill_in "Password", with: password
-      click_button "Log in"
+      click_on "Log in"
 
       # we expect to be redirected to the home page with a helpful flash message
       expect(page).to have_current_path(root_path, ignore_query: true)
@@ -34,7 +34,7 @@ RSpec.describe "User sign-in" do
       expect(response_cookies.keys.first).to match(/_session\z/)
 
       # when we click on the sign out link
-      click_link "Sign out"
+      click_on "Sign out"
 
       # we expect to still be on the home page with a flash message
       # telling us we have signed out.
@@ -48,7 +48,7 @@ RSpec.describe "User sign-in" do
         fill_in "Email", with: email
         fill_in "Password", with: password
         check "Remember me"
-        click_button "Log in"
+        click_on "Log in"
 
         # we expect to be redirected to the home page with a helpful flash message
         expect(page).to have_current_path(root_path, ignore_query: true)
@@ -79,7 +79,7 @@ RSpec.describe "User sign-in" do
         expect(Integer(remember_me_cookie_expiry_date - today_in_utc)).to eq(14)
 
         # when we click on the sign out link
-        click_link "Sign out"
+        click_on "Sign out"
 
         # we expect the "remember_user_token" cookie to have been removed i.e.
         # there will be exactly one cookie now (the session cookie)
@@ -96,7 +96,7 @@ RSpec.describe "User sign-in" do
         # when we fill in the sign-in form with a bad password
         fill_in "Email", with: email
         fill_in "Password", with: "wrong password"
-        click_button "Log in"
+        click_on "Log in"
 
         # we expect to still be on the sign-in page with a helpful flash message
         # telling us something went wrong

--- a/variants/devise/spec/system/user_sign_up_feature_spec.rb
+++ b/variants/devise/spec/system/user_sign_up_feature_spec.rb
@@ -16,10 +16,12 @@ RSpec.describe "User sign-up" do
 
   it "Users can sign-up" do
     # when we sign up with valid credentials
-    fill_in "Email", with: valid_email
-    fill_in "Password", with: valid_password
-    fill_in "Password confirmation", with: valid_password
-    click_button "Sign up"
+    within "form" do
+      fill_in "Email", with: valid_email
+      fill_in "Password", with: valid_password
+      fill_in "Password confirmation", with: valid_password
+      click_on "Sign up"
+    end
 
     # we expect to be redirected to the home page ...
     expect(page).to have_current_path(root_path, ignore_query: true)
@@ -32,10 +34,12 @@ RSpec.describe "User sign-up" do
   describe "email address validation" do
     it "email addresses are validated" do
       # when we sign up with an invalid email address
-      fill_in "Email", with: invalid_email
-      fill_in "Password", with: valid_password
-      fill_in "Password confirmation", with: valid_password
-      click_button "Sign up"
+      within "form" do
+        fill_in "Email", with: invalid_email
+        fill_in "Password", with: valid_password
+        fill_in "Password confirmation", with: valid_password
+        click_on "Sign up"
+      end
 
       # we expect to now be on the user registration page ...
       expect(page).to have_current_path(user_registration_path, ignore_query: true)
@@ -52,10 +56,12 @@ RSpec.describe "User sign-up" do
 
     it "passwords are validated for length" do
       # when we sign up with a password that is too short
-      fill_in "Email", with: valid_email
-      fill_in "Password", with: too_short_password
-      fill_in "Password confirmation", with: too_short_password
-      click_button "Sign up"
+      within "form" do
+        fill_in "Email", with: valid_email
+        fill_in "Password", with: too_short_password
+        fill_in "Password confirmation", with: too_short_password
+        click_on "Sign up"
+      end
 
       # we expect to now be on the user registration page ...
       expect(page).to have_current_path(user_registration_path, ignore_query: true)


### PR DESCRIPTION
https://github.com/rubocop/rubocop-capybara/pull/76 changed the default to enforce using the more generic `click_link_or_button` and `click_on` because

> These methods offer a weaker coupling between the test and HTML, allowing for a more faithful reflection of how the user behaves.

Which is very fair imo and inline with other testing frameworks like `testing-library`.