### PR TITLE
Update Puma configuration to set worker timeout in development environment

### DIFF
--- a/variants/backend-base/config/puma.rb
+++ b/variants/backend-base/config/puma.rb
@@ -14,7 +14,16 @@ threads min_threads_count, max_threads_count
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 port ENV.fetch("PORT", 3000)
-environment ENV.fetch("RAILS_ENV", "development")
+
+rails_env = ENV.fetch("RAILS_ENV", "development")
+
+environment rails_env
+
+if rails_env == "development"
+  # set a generous worker timeout so that the worker isn't killed by puma when
+  # suspended by a debugger
+  worker_timeout(3600)
+end
 
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")


### PR DESCRIPTION
This pull request updates the Puma configuration to set a worker timeout of 3600 seconds in the development environment. This ensures that the worker isn't killed by Puma when suspended by a debugger.

This steals an idea I saw in https://github.com/rails/rails/pull/50669/files. 