### PR TITLE
refactor: apply some formatting fixes

### DIFF
--- a/variants/accessibility/spec/system/home_feature_spec.rb
+++ b/variants/accessibility/spec/system/home_feature_spec.rb
@@ -1,1 +1,1 @@
-insert_into_file "spec/system/home_feature_spec.rb", "\n\nit_behaves_like \"an accessible page\"", after: /  end\n/
+insert_into_file "spec/system/home_feature_spec.rb", "\n\nit_behaves_like \"an accessible page\"\n", after: /  end\n/

--- a/variants/audit-logging/template.rb
+++ b/variants/audit-logging/template.rb
@@ -26,10 +26,10 @@ end
 insert_into_file "config/application.rb", before: /^  end/ do
   <<-RUBY
 
-    if ENV["RAILS_LOG_TO_STDOUT"].present?
-      config.audit_logger = Logger.new($stdout, formatter: AuditLogLogFormatter.new)
-    else
-      config.audit_logger = Logger.new("log/audit.log", formatter: AuditLogLogFormatter.new)
-    end
+    config.audit_logger = if ENV["RAILS_LOG_TO_STDOUT"].present?
+                            Logger.new($stdout, formatter: AuditLogLogFormatter.new)
+                          else
+                            Logger.new("log/audit.log", formatter: AuditLogLogFormatter.new)
+                          end
   RUBY
 end

--- a/variants/backend-base/config/application.rb
+++ b/variants/backend-base/config/application.rb
@@ -6,7 +6,7 @@ insert_into_file "config/application.rb", after: /^require_relative ['"]boot['"]
   # the empty line at the beginning of this string is required
   <<~RUBY
 
-    require_relative '../app/middleware/http_basic_auth'
+    require_relative "../app/middleware/http_basic_auth"
   RUBY
 end
 

--- a/variants/backend-base/config/environments/staging.rb.tt
+++ b/variants/backend-base/config/environments/staging.rb.tt
@@ -6,8 +6,8 @@ require_relative "./production"
 Rails.application.configure do
 
   config.action_mailer.default_url_options = {
-    :host => "<%= TEMPLATE_CONFIG.staging_hostname %>",
-    :protocol => "https"
+    host: "<%= TEMPLATE_CONFIG.staging_hostname %>",
+    protocol: "https"
   }
   config.action_mailer.asset_host = "https://<%= TEMPLATE_CONFIG.staging_hostname %>"
   config.action_mailer.smtp_settings[:domain] = "<%= TEMPLATE_CONFIG.staging_hostname %>"

--- a/variants/backend-base/config/environments/staging.rb.tt
+++ b/variants/backend-base/config/environments/staging.rb.tt
@@ -1,7 +1,7 @@
 # Staging configuration is identical to production, with some overrides
 # for hostname, etc.
 
-require_relative "./production"
+require_relative "production"
 
 Rails.application.configure do
 

--- a/variants/backend-base/config/template.rb
+++ b/variants/backend-base/config/template.rb
@@ -50,7 +50,7 @@ route <<-EO_ROUTES
     manifest_path = Shakapacker::Configuration
       .new(root_path: Rails.root, config_path: Rails.root.join("config/shakapacker.yml"), env: Rails.env)
       .public_manifest_path
-      .relative_path_from(Rails.root.join("public"))
+      .relative_path_from(Rails.public_path)
       .to_s
     get "/asset-manifest.json", to: redirect(manifest_path)
   end

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -54,7 +54,7 @@ copy_file "app/frontend/stylesheets/application.scss"
 prepend_to_file "app/frontend/packs/application.js" do
   <<~EO_CONTENT
 
-    import '../stylesheets/application.scss';
+    import "../stylesheets/application.scss";
   EO_CONTENT
 end
 

--- a/variants/frontend-bootstrap/template.rb
+++ b/variants/frontend-bootstrap/template.rb
@@ -4,12 +4,12 @@ yarn_add_dependencies(["bootstrap", "@popperjs/core"])
 run "yarn install"
 
 copy_file "app/frontend/js/bootstrap.js", force: true
-insert_into_file "app/frontend/packs/application.js", "import '../js/bootstrap';", before: "import '../stylesheets/application.scss';"
+insert_into_file "app/frontend/packs/application.js", "import '../js/bootstrap';", before: 'import "../stylesheets/application.scss";'
 
 copy_file "app/frontend/stylesheets/customized_bootstrap.scss", force: true
 prepend_to_file "app/frontend/stylesheets/application.scss" do
   <<~EO_CONTENT
-    @import '../stylesheets/customized_bootstrap';
+    @import "../stylesheets/customized_bootstrap";
   EO_CONTENT
 end
 

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -13,7 +13,7 @@ env:
   RAILS_ENV: test
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
   RAILS_SECRET_KEY_BASE: any-value-works-here-in-ci-but-prod-should-be-created-with-bundle-exec-rails-secret
-  MAIL_FROM: "changeme@example.com"
+  MAIL_FROM: 'changeme@example.com'
   <%- if TEMPLATE_CONFIG.apply_variant_sidekiq? -%>
   SIDEKIQ_WEB_USERNAME: admin
   SIDEKIQ_WEB_PASSWORD: password
@@ -45,8 +45,8 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v3
         with:
-          node-version-file: ".node-version"
-          cache: "yarn"
+          node-version-file: '.node-version'
+          cache: 'yarn'
       - run: yarn install --frozen-lockfile
       <%- if TEMPLATE_CONFIG.use_typescript? -%>
       - run: yarn run typecheck
@@ -61,15 +61,13 @@ jobs:
     services:
       db:
         image: postgres:latest
-        ports: ["5432:5432"]
+        ports: ['5432:5432']
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
           --health-retries 5
       # Uncomment these if you need them for your test suite
       # redis:
@@ -81,7 +79,7 @@ jobs:
       #   env:
       #     cluster.name: whats-on-test-cluster
       #     discovery.type: single-node
-      #     ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+      #     ES_JAVA_OPTS: '-Xms1g -Xmx1g'
       #   ports:
       #     - 9200:9200
       #     - 9300:9300
@@ -101,14 +99,13 @@ jobs:
       - name: Check Ruby controller annotations
         run: bundle exec chusaku --exit-with-error-on-annotation
       - run: bundle exec rubocop
-      - name: Run erb-lint to check HTML formatting and run Rubocop on Ruby within ERB
-        run: bundle exec erblint .
+      - run: bundle exec erblint .
       - run: bundle exec brakeman --run-all-checks .
       - run: bundle exec rails db:setup
       - uses: actions/setup-node@v3
         with:
-          node-version-file: ".node-version"
-          cache: "yarn"
+          node-version-file: '.node-version'
+          cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: bundle exec rspec spec --format progress
       - name: Archive spec outputs
@@ -141,7 +138,7 @@ jobs:
   #   with:
   #     environment: staging
   #     environment_url: '<%= "https://#{TEMPLATE_CONFIG.staging_hostname}" %>'
-  #     assume_role_arn: TODO # e.g. "arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>StagingGHARole"
+  #     assume_role_arn: TODO # e.g. 'arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>StagingGHARole'
   #     aws_region: ap-southeast-2 # Sydney
   #   secrets:
   #     ssh_private_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
@@ -159,7 +156,7 @@ jobs:
   #   with:
   #     environment: production
   #     environment_url: '<%= "https://#{TEMPLATE_CONFIG.production_hostname}" %>'
-  #     assume_role_arn: TODO # e.g. "arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>ProductionGHARole"
+  #     assume_role_arn: TODO # e.g. 'arn:aws:iam::<ACCOUNT_ID>:role/<CLIENT_NAME>ProductionGHARole'
   #     aws_region: ap-southeast-2 # Sydney
   #   secrets:
   #     ssh_private_key: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}

--- a/variants/pundit/template.rb
+++ b/variants/pundit/template.rb
@@ -65,7 +65,7 @@ end
 insert_into_file "config/locales/en.yml", after: /^en:\n/ do
   <<-YAML
   authorization:
-    not_authorized: "You are not authorised to perform this action."
+    not_authorized: 'You are not authorised to perform this action.'
   YAML
 end
 


### PR DESCRIPTION
These are some changes that are typically autofixed during generation - while there's no major drawback, I think it's nice to aim for our written template code to match our preferred formatting out of the gate.

MVP goes to `home_feature_spec.rb` whose lack of a newline upset not one but _three_ cops:

```
spec/system/home_feature_spec.rb:13:1: C: [Correctable] Layout/IndentationConsistency: Inconsistent indentation detected. (https://rubystyle.guide#spaces-indentation, https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions)
it_behaves_like "an accessible page"end
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/system/home_feature_spec.rb:13:37: C: [Correctable] Layout/BlockEndNewline: Expression at 13, 37 should be on its own line.
it_behaves_like "an accessible page"end
                                    ^^^
spec/system/home_feature_spec.rb:13:37: C: [Correctable] Layout/SpaceAroundKeyword: Space before keyword end is missing.
it_behaves_like "an accessible page"end
                                    ^^^
```