### PR TITLE
fix: explicitly set our preferred package manager for js dependencies

### DIFF
--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -16,6 +16,11 @@ remove_dir "app/assets/images"
 # this will create a package.json for us
 run "rails shakapacker:install"
 
+# explicitly set our preferred package manager for external tooling
+update_package_json do |package_json|
+  package_json["packageManager"] = "yarn@1.22.21"
+end
+
 # this is added by shakapacker:install, but we've already got one (with some extra tags)
 # in our template, so remove theirs otherwise the app will error when rendering this
 gsub_file "app/views/layouts/application.html.erb",


### PR DESCRIPTION
[`react-rails` now supports other package managers](https://github.com/reactjs/react-rails/pull/1306) using `package_json`, meaning it now defaults to `npm` if a package manager is not explicitly set in `package.json`, causing a stray `package-lock.json` to be created.

I've specified an exact version because currently `corepack` requires that ([ranges are not yet supported](https://github.com/nodejs/corepack/issues/95)) but we're not actually expecting anyone to be using `corepack` and we're definitely not using it in production (not explicitly at least...) so in theory this shouldn't cause problems and it means `package.json` conforms to the JSON schema - it'll also help to flush out any potential problems early before(/if) `corepack` becomes more mainstream.