### PR TITLE
fix: include running Jest tests as part of CI workflow

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -53,6 +53,7 @@ jobs:
       <%- end -%>
       - run: yarn run js-lint
       - run: yarn run format-check
+      - run: yarn run test --coverage
   ruby_based_checks:
     permissions:
       contents: read


### PR DESCRIPTION
I've included `--coverage` though we've not actually got a min. coverage target set so it won't enforce anything, but I think that's a separate thing.

Resolves #422