### PR TITLE
feat: report needless and invalid stylelint disables, and require descriptions

### DIFF
--- a/variants/frontend-base/.stylelintrc.js
+++ b/variants/frontend-base/.stylelintrc.js
@@ -1,6 +1,9 @@
 module.exports = {
   plugins: ['stylelint-scss'],
   extends: ['stylelint-config-recommended-scss'],
+  reportNeedlessDisables: true,
+  reportInvalidScopeDisables: true,
+  reportDescriptionlessDisables: true,
   rules: {
     'no-descending-specificity': null,
     'string-no-newline': true,


### PR DESCRIPTION
These mirror options we've got enabled in other linting like Rubocop, ESLint, and TypeScript