### PR TITLE
Optionally skip overcommit

### DIFF
--- a/variants/backend-base/bin/setup
+++ b/variants/backend-base/bin/setup
@@ -6,7 +6,7 @@ def setup!
     run  "gem install bundler --no-document --conservative"
     run  "bundle install"
     run  "yarn install" if File.exist?("yarn.lock")
-    run  "bundle exec overcommit --install"
+    run  "bundle exec overcommit --install" unless ENV["SKIP_OVERCOMMIT"] || ENV["CI"]
     copy "example.env"
     test_local_env_contains_required_keys
     run  "bin/rake tmp:create"


### PR DESCRIPTION
I don't use overcommit, i use hooks stored in dotfiles
overcommit helpfully installs its hooks in `[the project dir]/[a literal tilde]/.dotfiles/hooks` which is not what anyone wants.

this means i can turn this off when running the rails new everything command with rails template (usually i just won't use bin/setup directly)