### PR TITLE
Fix DST causing sign in spec to fail

### DIFF
--- a/variants/backend-base/spec/rails_helper.rb
+++ b/variants/backend-base/spec/rails_helper.rb
@@ -91,4 +91,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include ActiveSupport::Testing::TimeHelpers
+  config.after { travel_back }
 end


### PR DESCRIPTION
The issue seems to be that within the next 2 weeks is a dst change so we aren't 14 days away, we're 14 days +- 1 hour away (i can't be bothered figuring out which direction currently), which when rounded to days at utc was sometimes out by a day

by keeping the comparison to datetimes rather than a raw number of days or seconds, then ruby/rails can keep track of the impact of dst and things will just work

i've included the time helpers setup in base rather than in just the devise variant because i think it's broadly useful and its provided by rails we might as well make it accessible to rspec