### PR TITLE
feat: import Jest config type from `jest` rather than `@jest/types`

### DIFF
--- a/variants/frontend-stimulus-typescript/jest.config.ts
+++ b/variants/frontend-stimulus-typescript/jest.config.ts
@@ -1,7 +1,7 @@
-import { Config } from '@jest/types';
+import { Config } from 'jest';
 import 'ts-jest';
 
-const config: Config.InitialOptions = {
+const config: Config = {
   testEnvironment: 'jsdom',
   clearMocks: true,
   restoreMocks: true,

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -4,7 +4,6 @@ installed_jest_major_version = JSON.parse(File.read("node_modules/jest/package.j
 
 yarn_add_dev_dependencies [
   "@types/jest@#{installed_jest_major_version}",
-  "@jest/types@#{installed_jest_major_version}",
   "ts-jest@#{installed_jest_major_version}",
   "ts-node"
 ]


### PR DESCRIPTION
TIL `jest` re-exports this type from `@jest/types`, which means we can drop it as a direct dependency