### PR TITLE
perf: remove unneeded `yarn install` calls

### DIFF
--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -27,8 +27,6 @@ yarn_add_dev_dependencies %w[
   @typescript-eslint/eslint-plugin
 ]
 
-run "yarn install"
-
 rename_js_file_to_ts "app/frontend/packs/application"
 
 copy_file "tsconfig.json", force: true

--- a/variants/frontend-bootstrap-typescript/template.rb
+++ b/variants/frontend-bootstrap-typescript/template.rb
@@ -2,6 +2,4 @@ source_paths.unshift(File.dirname(__FILE__))
 
 yarn_add_dependencies %w[@types/bootstrap]
 
-run "yarn install"
-
 rename_js_file_to_ts "app/frontend/js/bootstrap"

--- a/variants/frontend-bootstrap/template.rb
+++ b/variants/frontend-bootstrap/template.rb
@@ -1,7 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
 yarn_add_dependencies(["bootstrap", "@popperjs/core"])
-run "yarn install"
 
 copy_file "app/frontend/js/bootstrap.js", force: true
 insert_into_file "app/frontend/packs/application.js", "import '../js/bootstrap';", before: 'import "../stylesheets/application.scss";'


### PR DESCRIPTION
Yarn already installs packages as part of adding them, so there's no need to immediately run `yarn install` afterwards