### PR TITLE
fix: lock ESLint to v8

### DIFF
--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -17,7 +17,7 @@ types_packages = %w[
   turbolinks
   dotenv-webpack
   webpack-env
-  eslint
+  eslint@8
   babel__core
 ].map { |name| "@types/#{name}" }
 

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -2,7 +2,7 @@
 # ######################################
 
 yarn_add_dev_dependencies %w[
-  eslint
+  eslint@8
   eslint-config-ackama
   eslint-plugin-node
   eslint-plugin-import


### PR DESCRIPTION
ESLint v9 has been released which drops support for the old config structure in favor of "flat config", which we're not yet ready to switch to