### PR TITLE
fix: check for `NoMethodError` instead of `NotImplementedError`

### DIFF
--- a/variants/pundit/template.rb
+++ b/variants/pundit/template.rb
@@ -8,6 +8,12 @@ run "bundle install"
 run "rails g pundit:install"
 run "rails g pundit:policy example"
 
+# Pundit uses NoMethodError which is easier to catch as it extends from StandardError,
+# but it's technically not correct as our class does respond to the method in question
+#
+# For now, we're just going to stick with the more traditional error for this situation
+gsub_file! "app/policies/application_policy.rb", "raise NoMethodError", "raise NotImplementedError"
+
 copy_file "spec/policies/example_policy_spec.rb", force: true
 copy_file "spec/policies/application_policy_spec.rb", force: true
 


### PR DESCRIPTION
[Pundit have recently changed](https://github.com/varvet/pundit/pull/776) to using `NoMethodError`, which breaks our spec - the main benefit of this change is that the new error extends from `StandardError` so in theory is easier to catch; however, it seems the community is divided as aside from the different superclass the existing error is more accurate since `NoMethodError` is meant to be thrown when the class does not `respond_to?` the method in question and that is not true.

I personally would like to keep using `NotImplementedError` though I'm happy to change if someone does prove a real-world situation where it's more burdson to catch (or that our error monitoring won't catch it), but I feel that should be a separate conversation - so this PR is changing it back to maintain our current status quo until such time that we do decide to change.