### PR TITLE
fix: support `shakapacker` v8

### DIFF
--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -13,13 +13,11 @@ end
 remove_dir "app/assets/stylesheets"
 remove_dir "app/assets/images"
 
-# this will create a package.json for us
-run "rails shakapacker:install"
+# create a basic package.json which explicitly sets our preferred package manager
+# for external tooling; shakapacker:install will add a _lot_ more for us later
+File.write("./package.json", JSON.generate({ "packageManager" => "yarn@1.22.21" }))
 
-# explicitly set our preferred package manager for external tooling
-update_package_json do |package_json|
-  package_json["packageManager"] = "yarn@1.22.21"
-end
+run "rails shakapacker:install"
 
 # this is added by shakapacker:install, but we've already got one (with some extra tags)
 # in our template, so remove theirs otherwise the app will error when rendering this
@@ -34,7 +32,6 @@ copy_file "config/webpack/webpack.config.js", force: true
 
 gsub_file! "config/shakapacker.yml", "cache_path: tmp/shakapacker", "cache_path: tmp/cache/shakapacker"
 gsub_file! "config/shakapacker.yml", "source_path: app/javascript", "source_path: app/frontend"
-gsub_file! "config/shakapacker.yml", "ensure_consistent_versioning: false", "ensure_consistent_versioning: true"
 
 old_shakapacker_test_compile_snippet = <<~EO_OLD
   test:


### PR DESCRIPTION
The most notable feature change in v8 is that Shakapacker is now JS package manager agnostic by default, using the [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) property to determine which package manager to use (otherwise defaulting to `npm`, like Node itself).

A side-effect of this means that `shakapacker:install` now _merges_ with existing `package.json`s rather than always overwriting it (that way you can set `packageManager` before running the installer); this means we could potentially refactor some of our `package.json` related code to reduce duplication but it'll still all work as-is so I've left that for a potential follow-up PR.

There are other breaking changes which are detailed [in the upgrade guide](https://github.com/shakacode/shakapacker/blob/main/docs/v8_upgrade.md) but they're mainly around fixing existing behaviour and removing deprecated stuff like the `webpacker` namespace; they will be relevant for our existing applications but don't impact new applications.