### PR TITLE
ci: upgrade `actions/setup-node` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: 'yarn'
@@ -141,7 +141,7 @@ jobs:
           sudo ln -s "$PWD/actionlint" /usr/local/bin/actionlint
 
       - name: Install NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: 'yarn'
           node-version-file: '.node-version'

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: 'yarn'
@@ -106,7 +106,7 @@ jobs:
       - run: bundle exec erblint .
       - run: bundle exec brakeman --run-all-checks .
       - run: bundle exec rails db:setup
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: 'yarn'


### PR DESCRIPTION
v4 uses a later version of Node but does not have any other notable breaking changes