### PR TITLE
fix: retain `@testing-library/dom` as a direct dependency even when `@testing-library/react` is used

### DIFF
--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -7,10 +7,7 @@ run "bundle install"
 
 run "rails generate react:install"
 
-# @testing-library/react brings in @testing-library/dom as a direct dependency,
-# and so should be favored when importing as it is the more specific package
-run "yarn remove @testing-library/dom"
-
+# prefer importing from the more specific package for consistency
 gsub_file! "app/frontend/test/stimulus/controllers/add_class_controller.test.js",
            "'@testing-library/dom'",
            "'@testing-library/react'"


### PR DESCRIPTION
[v16.0.0 now requires `@testing-library/dom` as a peer dependency](https://github.com/testing-library/react-testing-library/releases/tag/v16.0.0), which means we need to explicitly include it as a direct dependency at least while we're using Yarn which doesn't automatically install peer dependencies.

We already add `@testing-library/dom` as a direct dependency in the Stimulus variant which is always installed, so we just need to stop removing it in the React variant.