### PR TITLE
Centralise and improve Rails version handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,4 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
           PGHOST: localhost
-          # This version constraint string must match the value of the
-          # RAILS_REQUIREMENT constant in `./template.rb`
-          RAILS_VERSION_CONSTRAINT: '~> 7.1.1'
         run: ./ci/bin/build-and-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
@@ -174,4 +173,7 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
           PGHOST: localhost
+          # This version constraint string must match the value of the
+          # RAILS_REQUIREMENT constant in `./template.rb`
+          RAILS_VERSION_CONSTRAINT: '~> 7.1.1'
         run: ./ci/bin/build-and-test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,9 +16,24 @@ Rails:
   Enabled: true
 
 AllCops:
-  # Target the oldest version of Ruby that Rails 7 supports
-  TargetRubyVersion: 2.7
-  TargetRailsVersion: 7.1
+  # Target the oldest Ruby that this template's chosen Rails version supports In
+  # a normal Rails app, Rubocop would infer this from the version of Ruby
+  # running. We want the rubocop checks that run on this repo to work for any
+  # version of Ruby that the chosen Rails version supports so we have to be
+  # explicit.
+  TargetRubyVersion:
+    <%=
+    YAML.safe_load(Pathname.new("./target_versions.yml").realpath.read).fetch("minimum_ruby_major_minor")
+    %>
+
+  # In a normal Rails app, Rubocop would pull this from the Gemfile. We want the
+  # rubocop checks that run on this repo to be consistent with the checks that
+  # run on generated apps so we have to be explicit.
+  TargetRailsVersion:
+    <%=
+    YAML.safe_load(Pathname.new("./target_versions.yml").realpath.read).fetch("target_rails_major_minor")
+    %>
+
   NewCops: enable
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a template you can use to create new Rails applications.
   - [How do I use this?](#how-do-i-use-this)
   - [How do I use this template for every Rails app I create?](#how-do-i-use-this-template-for-every-rails-app-i-create)
   - [Contributing](#contributing)
+    - [Updating this template to a new Rails version](#updating-this-template-to-a-new-rails-version)
   - [Credits](#credits)
 
 ## Background
@@ -286,6 +287,13 @@ locally via the usual method:
 $ bundle install
 $ bundle exec rubocop # optionally adding -A for autofixes
 ```
+
+### Updating this template to a new Rails version
+
+1. Change the Rails and Ruby versions in
+   [./target_versions.yml](./target_versions.yml) as per the instructions in
+   that file.
+2. Update the template as required to support the new Rails version
 
 ## Credits
 

--- a/ci/bin/build-and-test
+++ b/ci/bin/build-and-test
@@ -1,12 +1,28 @@
 #!/usr/bin/env ruby
 
 require "fileutils"
+require "pathname"
+require "yaml"
+
+def ensure_everything_is_committed
+  out = `git status -s`
+
+  raise StandardError, "there are uncommitted changes or un-staged files: #{out}" unless out.empty?
+end
+
+def build_rails_version_specifier(target_versions_path)
+  major_minor = YAML.safe_load(File.read(target_versions_path)).fetch("target_rails_major_minor")
+
+  "~> #{major_minor}.0"
+end
 
 root_path = File.absolute_path(File.join(__dir__, "../.."))
 template_path = File.join(root_path, "template.rb")
 builds_path = File.join(root_path, "tmp/builds")
 app_name = ENV.fetch("APP_NAME", "app")
 app_path = File.join(builds_path, app_name)
+target_versions_path = File.join(root_path, "target_versions.yml")
+rails_version_specifier = build_rails_version_specifier(target_versions_path)
 
 config_path = if ENV.fetch("CONFIG_PATH", "") == ""
                 File.join(root_path, "ackama_rails_template.config.yml")
@@ -16,8 +32,6 @@ config_path = if ENV.fetch("CONFIG_PATH", "") == ""
 
 config_env_var = %Q(CONFIG_PATH="#{config_path}") if config_path
 skip_flags = ENV.fetch("SKIPS", "--skip-javascript --skip-docker")
-
-rails_version_constraint = ENV.fetch("RAILS_VERSION_CONSTRAINT")
 
 puts "=" * 80
 puts <<~EO_CONFIG_SUMMARY
@@ -34,8 +48,10 @@ puts "=" * 80
 
 raise "Missing config YML file" if config_path && !(File.exist?(config_path) && File.file?(config_path))
 
-puts "Installing latest rails gem"
-system "gem install rails --version '#{rails_version_constraint}' --no-document"
+puts "Installing latest compatible rails gem"
+install_output = `gem install rails --version '#{rails_version_specifier}' --no-document`
+rails_version = install_output.split("\n").first.strip.sub("Successfully installed rails-", "")
+puts "Using rails version #{rails_version}"
 
 unless Dir.exist?(builds_path)
   puts "Creating #{builds_path}"
@@ -49,19 +65,13 @@ end
 
 Dir.chdir(builds_path) do |cwd|
   puts "Working dir is now #{cwd}"
-  cmd = %Q(#{config_env_var} RACK_ENV=development RAILS_ENV=development rails new "#{app_name}" -d postgresql #{skip_flags} -m "#{template_path}")
+  cmd = %Q(#{config_env_var} TARGET_VERSIONS_PATH="#{target_versions_path}" RACK_ENV=development RAILS_ENV=development rails _#{rails_version}_ new "#{app_name}" -d postgresql #{skip_flags} -m "#{template_path}") # rubocop:disable Layout/LineLength
   puts <<~EO_HELP
     Build command:
     #{cmd}
   EO_HELP
 
   system(cmd, exception: true)
-end
-
-def ensure_everything_is_committed
-  out = `git status -s`
-
-  raise StandardError, "there are uncommitted changes or un-staged files: #{out}" unless out.empty?
 end
 
 puts "Running post-generator checks"

--- a/ci/bin/build-and-test
+++ b/ci/bin/build-and-test
@@ -17,6 +17,8 @@ config_path = if ENV.fetch("CONFIG_PATH", "") == ""
 config_env_var = %Q(CONFIG_PATH="#{config_path}") if config_path
 skip_flags = ENV.fetch("SKIPS", "--skip-javascript --skip-docker")
 
+rails_version_constraint = ENV.fetch("RAILS_VERSION_CONSTRAINT")
+
 puts "=" * 80
 puts <<~EO_CONFIG_SUMMARY
   Config summary:
@@ -33,7 +35,7 @@ puts "=" * 80
 raise "Missing config YML file" if config_path && !(File.exist?(config_path) && File.file?(config_path))
 
 puts "Installing latest rails gem"
-system "gem install rails --no-document"
+system "gem install rails --version '#{rails_version_constraint}' --no-document"
 
 unless Dir.exist?(builds_path)
   puts "Creating #{builds_path}"

--- a/ci/bin/build-and-test
+++ b/ci/bin/build-and-test
@@ -50,7 +50,16 @@ raise "Missing config YML file" if config_path && !(File.exist?(config_path) && 
 
 puts "Installing latest compatible rails gem"
 install_output = `gem install rails --version '#{rails_version_specifier}' --no-document`
-rails_version = install_output.split("\n").first.strip.sub("Successfully installed rails-", "")
+
+puts install_output # for ease of debugging
+
+rails_version = install_output
+                .split("\n")
+                .grep(/Successfully installed rails-/)
+                .first
+                .strip
+                .sub("Successfully installed rails-", "")
+
 puts "Using rails version #{rails_version}"
 
 unless Dir.exist?(builds_path)

--- a/ci/bin/build-and-test
+++ b/ci/bin/build-and-test
@@ -55,7 +55,7 @@ puts install_output # for ease of debugging
 
 rails_version = install_output
                 .split("\n")
-                .grep(/Successfully installed rails-/)
+                .grep(/Successfully installed rails-\d/)
                 .first
                 .strip
                 .sub("Successfully installed rails-", "")

--- a/target_versions.yml
+++ b/target_versions.yml
@@ -1,0 +1,8 @@
+# This template will work with Rails versions that match the given major.minor
+#
+# This is stored in a separate file so we can share it between the template and
+# our CI configuration.
+target_rails_major_minor: '7.1' # specify as major.minor
+
+# Set this to the minimum version of Ruby that the chosen Rails version supports.
+minimum_ruby_major_minor: '2.7'

--- a/template.rb
+++ b/template.rb
@@ -2,25 +2,21 @@ require "fileutils"
 require "shellwords"
 require "pp"
 
-# Express the Rails version as a requirement so that we will automatically
-# support the most recent patch version
-#
-# IMPORTANT: When you change this you must also update the
-# `RAILS_VERSION_CONSTRAINT` environment variable in `.githug/ci.yml` to ensure
-# that the CI runs against the correct version of Rails.
-RAILS_REQUIREMENT = "~> 7.1.1".freeze
-
 ##
 # This single template file will be downloaded and run by the `rails new`
 # command so all code it needs must be inlined we cannot load other files from
 # this repo.
 #
 class Config
-  DEFAULT_CONFIG_FILE_PATH = "../ackama_rails_template.config.yml".freeze
+  DEFAULT_CONFIG_PATH = "../ackama_rails_template.config.yml".freeze
+  DEFAULT_TARGET_VERSIONS_PATH = "../target_versions.yml".freeze
+
+  attr_reader :acceptable_rails_versions_specifier
 
   def initialize
-    config_file_path = File.absolute_path(ENV.fetch("CONFIG_PATH", DEFAULT_CONFIG_FILE_PATH))
+    config_file_path = File.absolute_path(ENV.fetch("CONFIG_PATH", DEFAULT_CONFIG_PATH))
     @yaml_config = YAML.safe_load(File.read(config_file_path))
+    @acceptable_rails_versions_specifier = load_acceptable_rails_versions_specifier
   end
 
   def staging_hostname
@@ -65,6 +61,22 @@ class Config
 
   def apply_variant_deploy_with_ackama_ec2_capistrano?
     @yaml_config.fetch("apply_variant_deploy_with_ackama_ec2_capistrano")
+  end
+
+  private
+
+  ##
+  # Rails version constraint is stored in a separate file so that it can be used
+  # outside of just the template
+  #
+  def load_acceptable_rails_versions_specifier
+    rel_path = ENV.fetch("TARGET_VERSIONS_PATH", DEFAULT_TARGET_VERSIONS_PATH)
+    abs_path = Pathname.new(rel_path).realpath
+    major_minor = YAML.safe_load(abs_path.read).fetch("target_rails_major_minor")
+
+    # Use the major.minor we got from the YAML file to build a RubyGems
+    # compatible specifier that will match all patch versions
+    "~> #{major_minor}.0"
   end
 end
 
@@ -312,11 +324,11 @@ def add_template_repository_to_source_path
 end
 
 def assert_minimum_rails_version
-  requirement = Gem::Requirement.new(RAILS_REQUIREMENT)
+  requirement = Gem::Requirement.new(TEMPLATE_CONFIG.acceptable_rails_versions_specifier)
   rails_version = Gem::Version.new(Rails::VERSION::STRING)
   return if requirement.satisfied_by?(rails_version)
 
-  puts "ERROR: This template requires Rails #{RAILS_REQUIREMENT}. You are using #{rails_version}"
+  puts "ERROR: This template requires Rails #{TEMPLATE_CONFIG.acceptable_rails_versions_specifier}. You are using #{rails_version}"
   exit 1
 end
 

--- a/template.rb
+++ b/template.rb
@@ -2,6 +2,12 @@ require "fileutils"
 require "shellwords"
 require "pp"
 
+# Express the Rails version as a requirement so that we will automatically
+# support the most recent patch version
+#
+# IMPORTANT: When you change this you must also update the
+# `RAILS_VERSION_CONSTRAINT` environment variable in `.githug/ci.yml` to ensure
+# that the CI runs against the correct version of Rails.
 RAILS_REQUIREMENT = "~> 7.1.1".freeze
 
 ##

--- a/variants/backend-base/Gemfile.tt
+++ b/variants/backend-base/Gemfile.tt
@@ -6,7 +6,7 @@ ruby File.read(".ruby-version")
 gem "rails", "<%= Rails.version %>"
 gem "puma"
 gem "pg"
-gem 'dotenv-rails', require: "dotenv/rails-now"
+gem 'dotenv-rails', require: "dotenv/load"
 gem "bootsnap", require: false
 
 gem "shakapacker"

--- a/variants/devise/template.rb
+++ b/variants/devise/template.rb
@@ -111,6 +111,15 @@ TERMINAL.puts_header "Adding example devise links to the homepage"
 
 append_to_file "app/views/application/_header.html.erb" do
   <<~ERB
+    <%=
+      content_tag(:style, nonce: content_security_policy_nonce) do
+        <<~STYLE
+          /* Temp style to pass Lighthouse audit */
+          a { display: block; padding: 0.5rem; }
+          input { padding: 0.5rem; margin: 0.5rem; }
+        STYLE
+      end
+    %>
     <nav class="navbar navbar-expand-sm navbar-light bg-light">
       <div class="container-fluid">
         <h1>Example devise nav</h1>

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -23,8 +23,8 @@ types_packages = %w[
 
 yarn_add_dependencies types_packages + %w[@babel/preset-typescript typescript]
 yarn_add_dev_dependencies %w[
-  @typescript-eslint/parser
-  @typescript-eslint/eslint-plugin
+  @typescript-eslint/eslint-plugin@7
+  @typescript-eslint/parser@7
 ]
 
 rename_js_file_to_ts "app/frontend/packs/application"


### PR DESCRIPTION
Create a central place to manage which versions of Ruby and Rails this template supports.

This change introduces a new configuration file called `target_verions.yml`. This file holds data about which versions of Ruby and Rails are currently compatible with the template. 

The data is used in multiple contexts:

1. The template itself uses it to verify that the version of Rails being used to run the template is compatible
2. CI uses it to choose a compatible version of Rails to install
3. Rubocop configuration for this repo uses it to ensure that Rubocop checks which run against this repo will be compatible with all versions of Ruby and Rails which the template supports. The Rubocop configuration in the generated apps does not need this information because it can infer it from the specific versions of Ruby and Rails in use in that app.

This change also 

* updates CI to always choose the most recent Rails version compatible with this template
* Gets CI passing - closes issue #550 