### PR TITLE
feat: don't automatically install frontend dependencies as part of `assets:precompile`

### DIFF
--- a/variants/backend-base/lib/tasks/assets.rake.tt
+++ b/variants/backend-base/lib/tasks/assets.rake.tt
@@ -1,8 +1,0 @@
-namespace :assets do
-  desc "Ensures that dependencies required to compile assets are installed"
-  task install_dependencies: :environment do
-    raise if File.exist?("package.json") && !(system "<%= package_json.manager.native_install_command(frozen: true).join(" ") %>")
-  end
-end
-
-Rake::Task["assets:precompile"].enhance ["assets:install_dependencies"]

--- a/variants/backend-base/lib/template.rb
+++ b/variants/backend-base/lib/template.rb
@@ -1,5 +1,3 @@
 copy_file "variants/backend-base/lib/tasks/coverage.rake", "lib/tasks/coverage.rake"
 copy_file "variants/backend-base/lib/tasks/app.rake", "lib/tasks/app.rake"
 copy_file "variants/backend-base/lib/tasks/dev.rake", "lib/tasks/dev.rake"
-
-template "variants/backend-base/lib/tasks/assets.rake.tt", "lib/tasks/assets.rake", force: true


### PR DESCRIPTION
This (for me at least) was always a bit of a weird one and something we introduced to be on the safe side rather than as a behaviour we'd explicitly decided was a good thing.

From what I understand it was born from webpacker/shakapacker having this behaviour as the default, which then later changed around shakapacker v6/v7 before finally being definitely removed in v8.

Now that it is gone, I think we should axe our task too as we generally always have our dependencies installed by this point and combining these two independent actions is horrible for caching (i.e. in images you typically copy just the `package.json` + lockfile, do the install command, then copy everything else and proceed), can undo optimizations (i.e. if in the aforementioned docker image I decide to install just my production dependencies, this'll then undo that), and even hide subtle "bugs" (i.e. if we forget to actually install our dependencies, this'll hide that which while technically does avoid an error, means we might not realize there's a larger issue with our pipeline).