### PR TITLE
ci: make `chusaku` output verbose

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -101,7 +101,7 @@ jobs:
       - name: Check Run Ruby model annotations
         run: bundle exec annotate --frozen
       - name: Check Ruby controller annotations
-        run: bundle exec chusaku --exit-with-error-on-annotation
+        run: bundle exec chusaku --verbose --exit-with-error-on-annotation
       - run: bundle exec rubocop
       - run: bundle exec erblint .
       - run: bundle exec brakeman --run-all-checks .


### PR DESCRIPTION
Without this, `chusaku` will just print a message saying that it has run but with no indication of what was actually missing an annotation, which can be annoying when you swear you did run it - even though the fix is to run `bundle exec chusaku` locally which doesn't require knowing what needs annotating, logs are free so we might as well be verbose here