### PR TITLE
fix: upgrade `actions/upload-artifact` to v4 in GitHub Actions variant

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -113,7 +113,7 @@ jobs:
       - run: <%= package_json.manager.native_install_command(frozen: true).join(" ") %>
       - run: bundle exec rspec spec --format progress
       - name: Archive spec outputs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: rspec-output-screenshots


### PR DESCRIPTION
v3 has been deprecated as v4 moves to an immutable-based design which has some performance benefits, among other things; that change doesn't impact how we're using artifacts, but that's all the more reason to upgrade.

See [the migration notes for more information](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) for more about what's changed.