### PR TITLE
fix: ensure env doesn't get clobbered when installing `package_json`

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -97,6 +97,8 @@ TERMINAL = Terminal.new
 JEST_MAJOR_VERSION = "29".freeze
 
 def require_package_json_gem
+  old_env = ENV.to_h
+
   require "bundler/inline"
 
   gemfile(true) do
@@ -105,6 +107,8 @@ def require_package_json_gem
   end
 
   puts "using package_json v#{PackageJson::VERSION}"
+
+  ENV.replace(old_env)
 end
 
 def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity


### PR DESCRIPTION
It seems that something had changed in Ruby 3.3.6 that means for some reason unless we maintain the old env, the use of `bundler/inline` causes Bundler to error about gems not being present when we (very) later call `run "bundle install"`.

I have no idea what has actually changed, as while I confirmed everything is passing if we switch to Ruby 3.3.5, I couldn't get a smaller reproducible example that showed the exact same behaviour 🤷 