### PR TITLE
fix: pin `eslint-config-ackama` to v3

### DIFF
--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -5,7 +5,7 @@ add_yarn_package_extension_dependency("eslint-plugin-prettier", "eslint-config-p
 
 yarn_add_dev_dependencies %w[
   eslint@8
-  eslint-config-ackama
+  eslint-config-ackama@3
   eslint-plugin-node
   eslint-plugin-import
   eslint-plugin-prettier


### PR DESCRIPTION
We released v4 of our config at the end of last year, which exports flat config by default unless the `ESLINT_USE_FLAT_CONFIG` environment variable is set to `false`.

While we want to upgrade to flat config and ESLint v9 ASAP, for now this just pins us to v3 to get CI passing again