### PR TITLE
feat: update rubocop config to use `plugins` instead of `require`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 # [rubocop.yml.tt](./rubocop.yml.tt) if you want to change the Rubocop
 # configuration which is copied into generated applications.
 ---
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance

--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -1,5 +1,5 @@
 ---
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance


### PR DESCRIPTION
[v1.72 introduced `plugins` as a replacement for `require`](https://docs.rubocop.org/rubocop/plugin_migration_guide.html#for-plugin-users), as part of introducing a new api for RuboCop extensions