### PR TITLE
feat: replace `annotate` with `annotaterb`

### DIFF
--- a/variants/backend-base/README.md.tt
+++ b/variants/backend-base/README.md.tt
@@ -169,9 +169,9 @@ npm run lighthouse-spec
 ### Source code annotations
 
 The [chusaku](https://github.com/nshki/chusaku) and
-[annotate](https://github.com/ctran/annotate_models) gems are installed in
+[annotaterb](https://github.com/drwl/annotaterb) gems are installed in
 development. Chusaku annotates controller actions with a comment detailing the
-route. Annotate annotates models and fixtures with a comment detailing the DB
+route. AnnotateRb annotates models and fixtures with a comment detailing the DB
 schema. You can run them manually via:
 
 ```bash
@@ -179,10 +179,10 @@ schema. You can run them manually via:
 bundle exec chusaku
 
 # update model, fixture, spec annotation comments (not usually required, auto-runs on migrations)
-bundle exec annotate
+bundle exec annotaterb models
 ```
 
-Annotate runs automatically after migrations. You will have to run Chusaku
+AnnotateRb runs automatically after migrations. You will have to run Chusaku
 manually after you add controller actions. CI verifies that these annotations
 are up to date.
 

--- a/variants/backend-base/spec/spec_helper.rb
+++ b/variants/backend-base/spec/spec_helper.rb
@@ -22,7 +22,7 @@ if RSpec.configuration.files_to_run.length > 1
     minimum_coverage line: 90, branch: 80
 
     add_filter "/bin/"
-    add_filter "/lib/tasks/auto_annotate_models.rake"
+    add_filter "/lib/tasks/annotate_rb.rake"
     add_filter "/lib/tasks/coverage.rake"
     add_filter "/spec/support/"
     add_filter "/spec/factories/"

--- a/variants/code-annotation/template.rb
+++ b/variants/code-annotation/template.rb
@@ -6,8 +6,8 @@ TERMINAL.puts_header "Installing code annotation gems"
 insert_into_file "Gemfile", after: /group :development do\n/ do
   <<-GEMS
   # code annotation
+  gem "annotaterb", require: false
   gem "chusaku", require: false
-  gem "annotate", require: false
 
   GEMS
 end
@@ -15,12 +15,15 @@ end
 run "bundle install"
 
 # adds a rake task which causes annotate to auto-run on every migration
-run "bundle exec rails generate annotate:install"
+run "bundle exec rails generate annotate_rb:install"
 
 TERMINAL.puts_header "Annotating code"
 
 run "bundle exec chusaku"
-run "bundle exec annotate"
+run "bundle exec annotaterb models"
+
+# we don't customize the config, and want to encourage consistency across apps
+remove_file ".annotaterb.yml"
 
 TERMINAL.puts_header "Running rubocop -A to fix formatting in files related to annotations"
 run "bundle exec rubocop -A -c ./.rubocop.yml"

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -99,7 +99,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Check Run Ruby model annotations
-        run: bundle exec annotate --frozen
+        run: bundle exec annotaterb models --frozen
       - name: Check Ruby controller annotations
         run: bundle exec chusaku --verbose --exit-with-error-on-annotation
       - run: bundle exec rubocop


### PR DESCRIPTION
The original gem is no longer being maintained, and does not support Rails v8 properly - `annotaterb` is a fork that is well maintained, though has some differences which are covered in [the migration guide](https://github.com/drwl/annotaterb/blob/main/MIGRATION_GUIDE.md).

I have reviewed the default configuration and it looks to be the same except for these two properties:

```
:hide_default_column_types: '' # was "json,jsonb,hstore",
:hide_limit_column_types: '' # was "integer,bigint,boolean",
```

I suspect this is fine as I didn't see any change on my internal app, but I'm going to apply this to a few other apps first to double check - ideally I'd like to avoid having to have an `.annotaterb.yml` if we can avoid it