### PR TITLE
fix: migrate all usages of `erblint` to `erb_lint`

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -229,12 +229,12 @@ def apply_template! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Met
     # generate routes and models
     apply "variants/code-annotation/template.rb"
 
-    # erblint does not like some of Rails auto-generated ERB code e.g.
+    # erb_lint does not like some of Rails auto-generated ERB code e.g.
     # `app/views/layouts/mailer.html.erb` so we auto-correct it.
     copy_file "variants/backend-base/.erb_lint.yml", ".erb_lint.yml"
-    run_with_clean_bundler_env "bundle exec erblint --autocorrect ."
+    run_with_clean_bundler_env "bundle exec erb_lint --autocorrect ."
     git add: "-A ."
-    git commit: "-n -m 'Set up erblint'"
+    git commit: "-n -m 'Set up erb_lint'"
 
     # Run strong_migrations generator near the end so that it doesn't block
     # other parts of the template from creating migrations.

--- a/variants/backend-base/Gemfile.tt
+++ b/variants/backend-base/Gemfile.tt
@@ -64,7 +64,7 @@ group :development, :test do
   gem "pry-rails"
   gem "pry-byebug"
 
-  # ERB linting. Run via `bundle exec erblint .`
+  # ERB linting. Run via `bundle exec erb_lint .`
   gem "erb_lint", require: false
 end
 

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -103,7 +103,7 @@ jobs:
       - name: Check Ruby controller annotations
         run: bundle exec chusaku --verbose --exit-with-error-on-annotation
       - run: bundle exec rubocop
-      - run: bundle exec erblint .
+      - run: bundle exec erb_lint .
       - run: bundle exec brakeman --run-all-checks .
       - run: bundle exec rails db:setup
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The gem has standardized on `erb_lint`, and will remove support for the old `erblint` command in a future version