### PR TITLE
feat: require all partials use strict locals

### DIFF
--- a/variants/backend-base/.erb_lint.yml
+++ b/variants/backend-base/.erb_lint.yml
@@ -19,6 +19,8 @@ linters:
   SelfClosingTag:
     enabled: true
     enforced_style: 'always'
+  StrictLocals:
+    enabled: true
   Rubocop:
     enabled: true
     rubocop_config:

--- a/variants/backend-base/app/views/application/_flash.html.erb
+++ b/variants/backend-base/app/views/application/_flash.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <%# Notice %>
 <% if flash[:notice].present? %>
   <div class="alert alert-success"><%= flash[:notice] %></div>

--- a/variants/backend-base/app/views/application/_header.html.erb
+++ b/variants/backend-base/app/views/application/_header.html.erb
@@ -1,1 +1,3 @@
+<%# locals: () %>
+
 <%# header and navigation menu %>

--- a/variants/backend-base/app/views/application/analytics/_body.html.erb
+++ b/variants/backend-base/app/views/application/analytics/_body.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <%# analytics configuration that goes in the <body> %>
 
 <% google_analytics_id = Rails.application.config.app.google_analytics_id %>

--- a/variants/backend-base/app/views/application/analytics/_head.html.erb
+++ b/variants/backend-base/app/views/application/analytics/_head.html.erb
@@ -1,3 +1,5 @@
+<%# locals: () %>
+
 <%# analytics configuration that goes in the <head> %>
 
 <% google_analytics_id = Rails.application.config.app.google_analytics_id %>

--- a/variants/devise/template.rb
+++ b/variants/devise/template.rb
@@ -222,3 +222,6 @@ run "bundle exec rubocop -A -c ./.rubocop.yml"
 
 git add: "-A ."
 git commit: "-n -m 'Install and configure devise with default Ackama settings'"
+
+append_to_file "app/views/users/shared/_error_messages.html.erb", "<%# locals: (resource:) %>\n\n"
+append_to_file "app/views/users/shared/_links.html.erb", "<%# locals: () %>\n\n"


### PR DESCRIPTION
[Strict locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals) are a special comment that explicitly declares what local variables an ERB partial accepts, along with default values for when an optional variable is not present.

This improvements performance when dealing with large collections and applications by making partials monomorphic (rather than polymorphic, which can potentially turn megamorphic) resulting in them being compiled only once regardless of the variations in their parameters; otherwise, a new version of the partial has to be compiled for each different set of parameters they're rendered with.

Additionally, these comments make it easier to understand the partial and for both humans and tools to catch silly mistakes, since the comment defines exactly what locals do and do not exist within the partial.

I expect in general this shouldn't be too painful, though we will need to handle this for partials that come from third-parties such as ActionText and Devise - my experience this so far has been very painless, and any mistakes should be caught by our test suites quite easily (as generally it just requires the partial to be rendered, even if nothing actually asserts the content).

Finally, I believe this form of the comment can serve as the ultimate bail out, allowing any local to be passed while still technically using strict locals:

```
<%# locals: (**attributes) %>
```