### PR TITLE
fix: ensure that all file manipulations are applied

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -493,4 +493,28 @@ def gsub_file!(path, flag, ...)
   raise StandardError, "the contents of #{path} did not change!" if content == File.binread(path)
 end
 
+def append_to_file!(path, ...)
+  content = File.binread(path)
+
+  append_to_file(path, ...)
+
+  raise StandardError, "the contents of #{path} did not change!" if content == File.binread(path)
+end
+
+def prepend_to_file!(path, ...)
+  content = File.binread(path)
+
+  prepend_to_file(path, ...)
+
+  raise StandardError, "the contents of #{path} did not change!" if content == File.binread(path)
+end
+
+def insert_into_file!(path, ...)
+  content = File.binread(path)
+
+  insert_into_file(path, ...)
+
+  raise StandardError, "the contents of #{path} did not change!" if content == File.binread(path)
+end
+
 apply_template!

--- a/variants/accessibility/Gemfile.rb
+++ b/variants/accessibility/Gemfile.rb
@@ -1,4 +1,4 @@
-insert_into_file "Gemfile", after: /gem "selenium-webdriver"\n/ do
+insert_into_file! "Gemfile", after: /gem "selenium-webdriver"\n/ do
   <<~GEMS
 
     gem "lighthouse-matchers"

--- a/variants/accessibility/spec/rails_helper.rb
+++ b/variants/accessibility/spec/rails_helper.rb
@@ -1,11 +1,11 @@
-insert_into_file "spec/rails_helper.rb", after: /require "selenium-webdriver"\n/ do
+insert_into_file! "spec/rails_helper.rb", after: /require "selenium-webdriver"\n/ do
   <<~REQUIRE
     require "lighthouse/matchers/rspec"
     require "axe/rspec"
   REQUIRE
 end
 
-insert_into_file "spec/rails_helper.rb", after: /# Add other Chrome arguments here\n/ do
+insert_into_file! "spec/rails_helper.rb", after: /# Add other Chrome arguments here\n/ do
   <<~OPTIONS
     # Lighthouse Matcher options
     options.add_argument("--remote-debugging-port=9222")
@@ -14,7 +14,7 @@ insert_into_file "spec/rails_helper.rb", after: /# Add other Chrome arguments he
 end
 
 if File.exist?(".yarnrc.yml")
-  insert_into_file "spec/rails_helper.rb", after: /# Lighthouse Matcher options\n/ do
+  insert_into_file! "spec/rails_helper.rb", after: /# Lighthouse Matcher options\n/ do
     <<~OPTIONS
       Lighthouse::Matchers.lighthouse_cli = "yarn run lighthouse"
     OPTIONS

--- a/variants/accessibility/spec/system/home_feature_spec.rb
+++ b/variants/accessibility/spec/system/home_feature_spec.rb
@@ -1,1 +1,1 @@
-insert_into_file "spec/system/home_feature_spec.rb", "\n\nit_behaves_like \"an accessible page\"\n", after: /  end\n/
+insert_into_file! "spec/system/home_feature_spec.rb", "\n\nit_behaves_like \"an accessible page\"\n", after: /  end\n/

--- a/variants/audit-logging/template.rb
+++ b/variants/audit-logging/template.rb
@@ -4,7 +4,7 @@ copy_file("variants/audit-logging/lib/audit_log_log_formatter.rb", "lib/audit_lo
 copy_file("variants/audit-logging/services/audit_log.rb", "app/services/audit_log.rb")
 copy_file("variants/audit-logging/spec/services/audit_log_spec.rb", "spec/services/audit_log_spec.rb")
 
-insert_into_file "app/controllers/application_controller.rb", after: /^  end/ do
+insert_into_file! "app/controllers/application_controller.rb", after: /^  end/ do
   <<-RUBY
 
 
@@ -17,13 +17,13 @@ insert_into_file "app/controllers/application_controller.rb", after: /^  end/ do
   RUBY
 end
 
-prepend_to_file "config/application.rb" do
+prepend_to_file! "config/application.rb" do
   <<~RUBY
     require_relative "../lib/audit_log_log_formatter"
   RUBY
 end
 
-insert_into_file "config/application.rb", before: /^  end/ do
+insert_into_file! "config/application.rb", before: /^  end/ do
   <<-RUBY
 
     config.audit_logger = if ENV["RAILS_LOG_TO_STDOUT"].present?

--- a/variants/backend-base/Rakefile.rb
+++ b/variants/backend-base/Rakefile.rb
@@ -1,4 +1,4 @@
-append_to_file "Rakefile" do
+append_to_file! "Rakefile" do
   <<~RUBY
 
     begin

--- a/variants/backend-base/config.ru.rb
+++ b/variants/backend-base/config.ru.rb
@@ -1,4 +1,4 @@
-insert_into_file "config.ru", before: /^run Rails.application/ do
+insert_into_file! "config.ru", before: /^run Rails.application/ do
   <<~RUBY
     use Rack::CanonicalHost, ENV["CANONICAL_HOSTNAME"] if ENV["CANONICAL_HOSTNAME"].present?
   RUBY

--- a/variants/backend-base/config/application.rb
+++ b/variants/backend-base/config/application.rb
@@ -2,7 +2,7 @@ gsub_file! "config/application.rb",
            /# config.time_zone = ['"]Central Time \(US & Canada\)['"]/,
            "config.time_zone = 'Wellington'"
 
-insert_into_file "config/application.rb", after: /^require_relative ['"]boot['"]/ do
+insert_into_file! "config/application.rb", after: /^require_relative ['"]boot['"]/ do
   # the empty line at the beginning of this string is required
   <<~RUBY
 
@@ -10,7 +10,7 @@ insert_into_file "config/application.rb", after: /^require_relative ['"]boot['"]
   RUBY
 end
 
-insert_into_file "config/application.rb", before: /^  end/ do
+insert_into_file! "config/application.rb", before: /^  end/ do
   # the empty line at the beginning of this string is required
   <<-RUBY
 

--- a/variants/backend-base/config/environments/development.rb
+++ b/variants/backend-base/config/environments/development.rb
@@ -1,7 +1,7 @@
 mailer_regex = /config\.action_mailer\.raise_delivery_errors = false\n/
 
 comment_lines "config/environments/development.rb", mailer_regex
-insert_into_file "config/environments/development.rb", after: mailer_regex do
+insert_into_file! "config/environments/development.rb", after: mailer_regex do
   <<-RUBY
 
   # Ensure mailer works in development.

--- a/variants/backend-base/config/environments/production.rb
+++ b/variants/backend-base/config/environments/production.rb
@@ -1,5 +1,5 @@
-insert_into_file "config/environments/production.rb",
-                 after: /# config\.assets\.css_compressor = :sass\n/ do
+insert_into_file! "config/environments/production.rb",
+                  after: /# config\.assets\.css_compressor = :sass\n/ do
   <<-RUBY
 
   # Disable minification since it adds a *huge* amount of time to precompile.
@@ -17,8 +17,8 @@ gsub_file! "config/environments/production.rb",
              config.force_ssl = ENV.fetch("RAILS_FORCE_SSL", "true").downcase != "false"
            RUBY
 
-insert_into_file "config/environments/production.rb",
-                 after: /# config\.action_mailer\.raise_deliv.*\n/ do
+insert_into_file! "config/environments/production.rb",
+                  after: /# config\.action_mailer\.raise_deliv.*\n/ do
   <<-RUBY
 
   # Production email config
@@ -50,8 +50,8 @@ gsub_file! "config/environments/production.rb",
            "ActiveSupport::Logger.new(STDOUT)",
            "ActiveSupport::Logger.new($stdout)"
 
-insert_into_file "config/environments/production.rb",
-                 after: /.*config\.public_file_server\.enabled.*\n/ do
+insert_into_file! "config/environments/production.rb",
+                  after: /.*config\.public_file_server\.enabled.*\n/ do
   <<~'RUBY'
 
     # Ensure that Rails sets appropriate caching headers on static assets if
@@ -85,8 +85,8 @@ insert_into_file "config/environments/production.rb",
   RUBY
 end
 
-insert_into_file "config/environments/production.rb",
-                 after: /.*config.cache_store = :mem_cache_store\n/ do
+insert_into_file! "config/environments/production.rb",
+                  after: /.*config.cache_store = :mem_cache_store\n/ do
   <<~RUBY
     if ENV.fetch("RAILS_CACHE_REDIS_URL", nil)
       config.cache_store = :redis_cache_store, {

--- a/variants/backend-base/config/environments/test.rb
+++ b/variants/backend-base/config/environments/test.rb
@@ -1,4 +1,4 @@
-insert_into_file \
+insert_into_file! \
   "config/environments/test.rb",
   after: /config\.action_mailer\.delivery_method = :test\n/ do
   <<-RUBY

--- a/variants/bullet/template.rb
+++ b/variants/bullet/template.rb
@@ -1,4 +1,4 @@
-insert_into_file "Gemfile", after: /^group :development, :test do\n/ do
+insert_into_file! "Gemfile", after: /^group :development, :test do\n/ do
   <<~GEMS
     gem "bullet"
   GEMS
@@ -6,7 +6,7 @@ end
 
 run "bundle install"
 
-insert_into_file "config/environments/development.rb", before: /^end/ do
+insert_into_file! "config/environments/development.rb", before: /^end/ do
   <<-RUBY
 
   # Bullet makes inline javascript, so there is warning in console in browse until content security policy change
@@ -29,7 +29,7 @@ insert_into_file "config/environments/development.rb", before: /^end/ do
   RUBY
 end
 
-insert_into_file "config/environments/test.rb", before: /^end/ do
+insert_into_file! "config/environments/test.rb", before: /^end/ do
   <<-RUBY
 
   config.after_initialize do

--- a/variants/code-annotation/template.rb
+++ b/variants/code-annotation/template.rb
@@ -3,7 +3,7 @@ source_paths.unshift(File.dirname(__FILE__))
 
 TERMINAL.puts_header "Installing code annotation gems"
 
-insert_into_file "Gemfile", after: /group :development do\n/ do
+insert_into_file! "Gemfile", after: /group :development do\n/ do
   <<-GEMS
   # code annotation
   gem "annotaterb", require: false

--- a/variants/deploy_with_ackama_ec2_capistrano/template.rb
+++ b/variants/deploy_with_ackama_ec2_capistrano/template.rb
@@ -2,7 +2,7 @@ TERMINAL.puts_header "Starting variant: deploy_with_ackama_ec2_capistrano"
 
 copy_file "variants/deploy_with_ackama_ec2_capistrano/aws_ec2_environment.yml", "config/aws_ec2_environment.yml"
 
-append_to_file("Gemfile") do
+append_to_file!("Gemfile") do
   <<~EO_RUBY
 
     # Deployment
@@ -146,7 +146,7 @@ EO_RUBY
 
 gsub_file!("config/deploy.rb", old_generated_cap_config_snippet, new_ackama_cap_config_snippet)
 
-insert_into_file "Capfile", after: /install_plugin Capistrano::SCM::Git/ do
+insert_into_file! "Capfile", after: /install_plugin Capistrano::SCM::Git/ do
   <<~EO_RUBY
     # Include tasks from other gems included in your Gemfile
     #
@@ -183,7 +183,7 @@ deploy_envs.each do |env_name, file_path|
                          "TODO_branch_name"
                        end
 
-  prepend_to_file(file_path) do
+  prepend_to_file!(file_path) do
     <<~EO_RUBY
       # These are the most common settings required to deploy to a server
       set :rails_env, "#{env_name}"
@@ -233,4 +233,4 @@ new_readme_content = <<~EO_CONTENT
 
 EO_CONTENT
 
-append_to_file("README.md", new_readme_content)
+append_to_file!("README.md", new_readme_content)

--- a/variants/deploy_with_capistrano/template.rb
+++ b/variants/deploy_with_capistrano/template.rb
@@ -1,6 +1,6 @@
 TERMINAL.puts_header "Starting variant: deploy_with_capistrano"
 
-append_to_file("Gemfile") do
+append_to_file!("Gemfile") do
   <<~EO_RUBY
 
     # Deployment
@@ -134,7 +134,7 @@ EO_RUBY
 
 gsub_file!("config/deploy.rb", old_generated_cap_config_snippet, new_ackama_cap_config_snippet)
 
-insert_into_file "Capfile", after: /install_plugin Capistrano::SCM::Git/ do
+insert_into_file! "Capfile", after: /install_plugin Capistrano::SCM::Git/ do
   <<~EO_RUBY
     # Include tasks from other gems included in your Gemfile
     #
@@ -171,7 +171,7 @@ deploy_envs.each do |env_name, file_path|
                          "TODO_branch_name"
                        end
 
-  prepend_to_file(file_path) do
+  prepend_to_file!(file_path) do
     <<~EO_RUBY
       # These are the most common settings required to deploy to a server
       set :rails_env, "#{env_name}"
@@ -203,4 +203,4 @@ new_readme_content = <<~EO_CONTENT
 
 EO_CONTENT
 
-append_to_file("README.md", new_readme_content)
+append_to_file!("README.md", new_readme_content)

--- a/variants/devise/template.rb
+++ b/variants/devise/template.rb
@@ -109,7 +109,7 @@ EO_ROUTES
 #
 TERMINAL.puts_header "Adding example devise links to the homepage"
 
-append_to_file "app/views/application/_header.html.erb" do
+append_to_file! "app/views/application/_header.html.erb" do
   <<~ERB
     <%=
       content_tag(:style, nonce: content_security_policy_nonce) do
@@ -154,7 +154,7 @@ gsub_file! "config/routes.rb",
              }
            EO_DEVISE
 
-insert_into_file "app/models/user.rb", before: /^end/ do
+insert_into_file! "app/models/user.rb", before: /^end/ do
   <<~'RUBY'
 
     ##

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -62,7 +62,7 @@ package_json.merge! do |pj|
   }
 end
 
-append_to_file "bin/ci-run" do
+append_to_file! "bin/ci-run" do
   <<~TYPECHECK
 
     echo "* ******************************************************"

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -33,7 +33,7 @@ package_json.merge! do |pj|
   }
 end
 
-append_to_file "bin/ci-run" do
+append_to_file! "bin/ci-run" do
   <<~ESLINT
 
     echo "* ******************************************************"
@@ -43,7 +43,7 @@ append_to_file "bin/ci-run" do
   ESLINT
 end
 
-append_to_file "bin/ci-run" do
+append_to_file! "bin/ci-run" do
   <<~PRETTIER
 
     echo "* ******************************************************"
@@ -63,7 +63,7 @@ yarn_add_dev_dependencies %w[
 copy_file "variants/frontend-base/.stylelintrc.js", ".stylelintrc.js"
 template "variants/frontend-base/.stylelintignore.tt", ".stylelintignore"
 
-append_to_file "bin/ci-run" do
+append_to_file! "bin/ci-run" do
   <<~SASSLINT
 
     echo "* ******************************************************"

--- a/variants/frontend-base/sentry/template.rb
+++ b/variants/frontend-base/sentry/template.rb
@@ -3,9 +3,9 @@
 
 yarn_add_dependencies %w[@sentry/browser dotenv-webpack]
 
-prepend_to_file "app/frontend/packs/application.js", "import * as Sentry from '@sentry/browser';"
+prepend_to_file! "app/frontend/packs/application.js", "import * as Sentry from '@sentry/browser';"
 
-append_to_file "app/frontend/packs/application.js" do
+append_to_file! "app/frontend/packs/application.js" do
   <<~EO_JS
 
     // Initialize Sentry Error Reporting
@@ -32,7 +32,7 @@ append_to_file "app/frontend/packs/application.js" do
   EO_JS
 end
 
-prepend_to_file "app/frontend/packs/application.js" do
+prepend_to_file! "app/frontend/packs/application.js" do
   <<~EO_JS
     // The application.js pack is deferred by default which means that nothing imported
     // in this file will begin executing until after the page has loaded. This helps to

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -57,7 +57,7 @@ empty_directory_with_keep_file "app/frontend/images"
 copy_file "app/frontend/stylesheets/_elements.scss"
 copy_file "app/frontend/stylesheets/_reset.scss"
 copy_file "app/frontend/stylesheets/application.scss"
-prepend_to_file "app/frontend/packs/application.js" do
+prepend_to_file! "app/frontend/packs/application.js" do
   <<~EO_CONTENT
 
     import "../stylesheets/application.scss";
@@ -107,7 +107,7 @@ yarn_add_dependencies %w[
 yarn_add_dependencies %w[
   @hotwired/turbo-rails
 ]
-prepend_to_file "app/frontend/packs/application.js" do
+prepend_to_file! "app/frontend/packs/application.js" do
   <<~EO_CONTENT
 
     import "@hotwired/turbo-rails"

--- a/variants/frontend-bootstrap/template.rb
+++ b/variants/frontend-bootstrap/template.rb
@@ -3,10 +3,10 @@ source_paths.unshift(File.dirname(__FILE__))
 yarn_add_dependencies(["bootstrap", "@popperjs/core"])
 
 copy_file "app/frontend/js/bootstrap.js", force: true
-insert_into_file "app/frontend/packs/application.js", "import '../js/bootstrap';", before: 'import "../stylesheets/application.scss";'
+insert_into_file! "app/frontend/packs/application.js", "import '../js/bootstrap';", before: 'import "../stylesheets/application.scss";'
 
 copy_file "app/frontend/stylesheets/customized_bootstrap.scss", force: true
-append_to_file "app/frontend/stylesheets/application.scss" do
+append_to_file! "app/frontend/stylesheets/application.scss" do
   <<~EO_CONTENT
 
     // We use @import because Bootstrap will not support @use until v6. See

--- a/variants/frontend-react-typescript/template.rb
+++ b/variants/frontend-react-typescript/template.rb
@@ -25,7 +25,7 @@ tsconfig_json = JSON.parse(File.read("./tsconfig.json"))
 tsconfig_json["compilerOptions"]["jsx"] = "react"
 File.write("./tsconfig.json", JSON.generate(tsconfig_json))
 
-append_to_file "types.d.ts" do
+append_to_file! "types.d.ts" do
   <<~TYPES
     declare module 'react_ujs' {
       import RequireContext = __WebpackModuleApi.RequireContext;

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -51,8 +51,8 @@ gsub_file!(
   ""
 )
 
-prepend_to_file "app/frontend/packs/application.js",
-                "import ReactRailsUJS from 'react_ujs';\n"
+prepend_to_file! "app/frontend/packs/application.js",
+                 "import ReactRailsUJS from 'react_ujs';\n"
 
 gsub_file!(
   "app/frontend/packs/server_rendering.js",
@@ -69,7 +69,7 @@ copy_file "jest.config.js"
 copy_file "app/frontend/components/HelloWorld.jsx", force: true
 copy_file "app/frontend/test/components/HelloWorld.spec.jsx", force: true
 
-append_to_file "app/views/home/index.html.erb" do
+append_to_file! "app/views/home/index.html.erb" do
   <<~ERB
     <%= react_component("HelloWorld", { initialGreeting: "Hello from react-rails." }) %>
   ERB

--- a/variants/frontend-stimulus/template.rb
+++ b/variants/frontend-stimulus/template.rb
@@ -10,14 +10,14 @@ yarn_add_dependencies %w[
 directory "app/frontend/stimulus/controllers"
 directory "app/frontend/test"
 
-prepend_to_file "app/frontend/packs/application.js" do
+prepend_to_file! "app/frontend/packs/application.js" do
   <<~EO_JS_IMPORTS
     import { Application } from '@hotwired/stimulus';
     import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers';
   EO_JS_IMPORTS
 end
 
-append_to_file "app/frontend/packs/application.js" do
+append_to_file! "app/frontend/packs/application.js" do
   <<~EO_JS_SETUP
 
     // Set up stimulus.js https://stimulus.hotwired.dev/
@@ -70,7 +70,7 @@ package_json.merge! do |pj|
   }
 end
 
-append_to_file "bin/ci-run" do
+append_to_file! "bin/ci-run" do
   <<~JEST
     echo "* ******************************************************"
     echo "* Running JS tests"

--- a/variants/github_actions_ci/template.rb
+++ b/variants/github_actions_ci/template.rb
@@ -2,7 +2,7 @@ template "variants/github_actions_ci/workflows/ci.yml.tt", ".github/workflows/ci
 copy_file "variants/github_actions_ci/workflows/deploy_to_ec2.yml", ".github/workflows/deploy_to_ec2.yml"
 copy_file "variants/github_actions_ci/workflows/deploy_to_heroku.yml", ".github/workflows/deploy_to_heroku.yml"
 
-append_to_file "bin/ci-run" do
+append_to_file! "bin/ci-run" do
   <<~ACTIONLINT
 
     echo "* ******************************************************"

--- a/variants/pundit/template.rb
+++ b/variants/pundit/template.rb
@@ -18,8 +18,8 @@ copy_file "spec/policies/example_policy_spec.rb", force: true
 copy_file "spec/policies/application_policy_spec.rb", force: true
 
 # Configure app/controllers/application_controller.rb
-insert_into_file "app/controllers/application_controller.rb",
-                 after: /^class ApplicationController < ActionController::Base\n/ do
+insert_into_file! "app/controllers/application_controller.rb",
+                  after: /^class ApplicationController < ActionController::Base\n/ do
   <<-RUBY
   include Pundit::Authorization
 
@@ -29,7 +29,7 @@ insert_into_file "app/controllers/application_controller.rb",
   RUBY
 end
 
-insert_into_file "app/controllers/application_controller.rb", before: /^end/ do
+insert_into_file! "app/controllers/application_controller.rb", before: /^end/ do
   <<-RUBY
 
   private
@@ -68,20 +68,20 @@ insert_into_file "app/controllers/application_controller.rb", before: /^end/ do
   RUBY
 end
 
-insert_into_file "config/locales/en.yml", after: /^en:\n/ do
+insert_into_file! "config/locales/en.yml", after: /^en:\n/ do
   <<-YAML
   authorization:
     not_authorized: 'You are not authorised to perform this action.'
   YAML
 end
 
-insert_into_file "spec/rails_helper.rb", after: %r{require "axe/rspec"\n} do
+insert_into_file! "spec/rails_helper.rb", after: %r{require "axe/rspec"\n} do
   <<~REQUIRE
     require "pundit/rspec"
   REQUIRE
 end
 
-insert_into_file "app/controllers/home_controller.rb", after: /def index\n/ do
+insert_into_file! "app/controllers/home_controller.rb", after: /def index\n/ do
   <<-RUBY
     # tell pundit that we are ok with not having authorization on this endpoint
     skip_policy_scope

--- a/variants/sidekiq/template.rb
+++ b/variants/sidekiq/template.rb
@@ -6,10 +6,10 @@ gem "sentry-sidekiq"
 run "bundle install"
 run "bundle binstubs sidekiq --force"
 
-append_to_file "Procfile", "worker:  bundle exec sidekiq -C config/sidekiq.yml"
+append_to_file! "Procfile", "worker:  bundle exec sidekiq -C config/sidekiq.yml"
 
 %w[example.env .env].each do |env_file|
-  append_to_file env_file do
+  append_to_file! env_file do
     <<~CONTENT
       REDIS_URL=redis://localhost:6379/#{rand(16)}
       SIDEKIQ_WEB_USERNAME=admin
@@ -21,7 +21,7 @@ end
 template "config/initializers/sidekiq.rb"
 copy_file "config/sidekiq.yml"
 
-insert_into_file "config/application.rb", before: /^  end/ do
+insert_into_file! "config/application.rb", before: /^  end/ do
   <<-RUBY
 
     # Use sidekiq to process Active Jobs (e.g. ActionMailer's deliver_later)
@@ -29,7 +29,7 @@ insert_into_file "config/application.rb", before: /^  end/ do
   RUBY
 end
 
-insert_into_file "docker-compose.yml", "
+insert_into_file! "docker-compose.yml", "
   worker:
     <<: *rails
     command: bundle exec sidekiq


### PR DESCRIPTION
The file manipulation methods provided by Thor don't stop execution when they fail to do the defined manipulation, instead in our case they print an error but then proceed; we actually want to error in this situation since the whole point of our template is to be applying our preferred practices meaning its moot if we don't...

This really came into light with the Rails 8 upgrade which had a number of changes to the configuration files in particular that caused a number of our customizations to be skipped.

By introducing bang versions of the methods that error if the file contents does not change, we can ensure going forward all manipulations actually work; this uses the same logic I introduced in #533 for `gsub_file`, and caught a bug that I fixed in #596