### PR TITLE
fix(sidekiq): update regexp for updating `docker-compose.yml` to properly match

### DIFF
--- a/variants/sidekiq/template.rb
+++ b/variants/sidekiq/template.rb
@@ -37,7 +37,7 @@ insert_into_file "docker-compose.yml", "
       - redis
   redis:
     image: redis
-", after: /^services:$"/
+", after: /^services:\n/
 
 route <<~ROUTE
   ##


### PR DESCRIPTION
The current regexp will never work because it's expecting a double quote character after the end of the line, which is impossible for two reasons.

Instead, I've replaced both characters with a newline as that feels like a better match (though really in hindsight just removing the double quote probably would have been enough to fix this 😅)

Found via #595