### PR TITLE
fix: re-enable `strict` lint rule for files that don't get compiled

### DIFF
--- a/variants/frontend-base-typescript/.eslintrc.js
+++ b/variants/frontend-base-typescript/.eslintrc.js
@@ -19,7 +19,8 @@ const config = {
       rules: {
         '@typescript-eslint/prefer-nullish-coalescing': 'off',
         '@typescript-eslint/no-require-imports': 'off',
-        '@typescript-eslint/no-var-requires': 'off'
+        '@typescript-eslint/no-var-requires': 'off',
+        'strict': 'error'
       }
     }
   ],

--- a/variants/frontend-react-typescript/.eslintrc.js
+++ b/variants/frontend-react-typescript/.eslintrc.js
@@ -24,7 +24,8 @@ const config = {
       rules: {
         '@typescript-eslint/prefer-nullish-coalescing': 'off',
         '@typescript-eslint/no-require-imports': 'off',
-        '@typescript-eslint/no-var-requires': 'off'
+        '@typescript-eslint/no-var-requires': 'off',
+        'strict': 'error'
       }
     },
     {

--- a/variants/frontend-stimulus-typescript/.eslintrc.js
+++ b/variants/frontend-stimulus-typescript/.eslintrc.js
@@ -19,7 +19,8 @@ const config = {
       rules: {
         '@typescript-eslint/prefer-nullish-coalescing': 'off',
         '@typescript-eslint/no-require-imports': 'off',
-        '@typescript-eslint/no-var-requires': 'off'
+        '@typescript-eslint/no-var-requires': 'off',
+        'strict': 'error'
       }
     },
     {


### PR DESCRIPTION
This rule is turned off by our TypeScript config, since consuming TypeScript involves compiling it into native JavaScript which handles applying strict mode, but our config files are not compiled so we should ensure they explicitly enable strict mode