### PR TITLE
fix(devise): prepend strict local hints to erb templates

### DIFF
--- a/variants/devise/template.rb
+++ b/variants/devise/template.rb
@@ -223,5 +223,5 @@ run "bundle exec rubocop -A -c ./.rubocop.yml"
 git add: "-A ."
 git commit: "-n -m 'Install and configure devise with default Ackama settings'"
 
-append_to_file "app/views/users/shared/_error_messages.html.erb", "<%# locals: (resource:) %>\n\n"
-append_to_file "app/views/users/shared/_links.html.erb", "<%# locals: () %>\n\n"
+prepend_to_file! "app/views/users/shared/_error_messages.html.erb", "<%# locals: (resource:) %>\n\n"
+prepend_to_file! "app/views/users/shared/_links.html.erb", "<%# locals: () %>\n\n"


### PR DESCRIPTION
I realised right after I landed #595 that I'd forgotten to double check after rebasing that I've replaced new usages of the file manipulation methods, but then as I was preparing this I _also_ realized that we're meant to be prepending the `locals` comments into the templates 🤦