### PR TITLE
chore: use single quotes instead of double

### DIFF
--- a/variants/backend-base/Gemfile.tt
+++ b/variants/backend-base/Gemfile.tt
@@ -6,7 +6,7 @@ ruby File.read(".ruby-version")
 gem "rails", "<%= Rails.version %>"
 gem "puma"
 gem "pg"
-gem 'dotenv-rails', require: "dotenv/load"
+gem "dotenv-rails", require: "dotenv/load"
 gem "bootsnap", require: false
 
 gem "shakapacker"


### PR DESCRIPTION
Rubocop automatically fixes this as part of the generation, but might as well just change it at the source to reduce the diff of our commits