### PR TITLE
feat: reuse existing environment config comments to avoid doubling up

### DIFF
--- a/ci/bin/build-and-test
+++ b/ci/bin/build-and-test
@@ -4,6 +4,8 @@ require "fileutils"
 require "pathname"
 require "yaml"
 
+require_relative "lint-configs"
+
 def ensure_everything_is_committed
   out = `git status -s`
 
@@ -89,6 +91,9 @@ Dir.chdir(app_path) do |cwd|
 
   puts "Checking everything is committed and there are no un-staged files"
   ensure_everything_is_committed
+
+  puts "Checking that no config properties have been duplicated in environment files"
+  ensure_no_duplicate_config_lines_in_environment_files
 
   puts "Running test suite"
   system("./bin/ci-run", exception: true)

--- a/ci/bin/lint-configs.rb
+++ b/ci/bin/lint-configs.rb
@@ -1,28 +1,53 @@
 #!/usr/bin/env ruby
 
-def ensure_no_duplicate_config_lines_in_environment_files
-  Dir.glob("**/config/environments/*.rb").each do |file|
-    # @type [Array<String>]
-    properties = []
+# Checks the given file for repeated "config.xyz = " lines
+#
+# @param [String] file
+#
+# @return [Array<String>]
+def check_file_for_repeated_config_properties(file)
+  # @type [Array<String>]
+  seen = []
+  # @type [Array<String>]
+  duplicates = []
+  in_condition = false
 
-    in_condition = false
+  File.readlines(file).each do |line|
+    in_condition = true if line.strip.start_with?("if")
+    in_condition = false if line.strip == "end"
 
-    File.readlines(file).each do |line|
-      in_condition = true if line.strip.start_with?("if")
-      in_condition = false if line.strip == "end"
+    # ignore conditions for now
+    next if in_condition
 
-      next if in_condition
+    line.match(/(config\.[a-zA-Z_]+) = /) do |match|
+      duplicates << match[1] if seen.include?(match[1])
 
-      line.match(/config\.[a-zA-Z_]+ = /) do |match|
-        property = match[0]
-        if properties.include?(property)
-          puts "#{file}: #{line}"
-        else
-          properties << property
-        end
-      end
+      seen << match[1]
     end
   end
+
+  duplicates
+end
+
+# Checks each environment config file for duplicate config properties,
+# as we should be reusing lines where possible to avoid confusion
+# and reduce the diff when doing Rails upgrades on applications
+def ensure_no_duplicate_config_lines_in_environment_files
+  # @type [Hash<String, Array<String>>]
+  results = {}
+
+  Dir.glob("**/config/environments/*.rb").each do |file|
+    results[file] = check_file_for_repeated_config_properties(file)
+  end
+
+  results.reject! { |_, duplicates| duplicates.empty? }
+
+  results.each do |file, duplicates|
+    puts "#{file} has duplicate config properties:"
+    duplicates.each { |line| puts "  - #{line}" }
+  end
+
+  raise "one or more environment files had duplicate configs" unless results.empty?
 end
 
 if __FILE__ == $PROGRAM_NAME

--- a/ci/bin/lint-configs.rb
+++ b/ci/bin/lint-configs.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+def ensure_no_duplicate_config_lines_in_environment_files
+  Dir.glob("**/config/environments/*.rb").each do |file|
+    # @type [Array<String>]
+    properties = []
+
+    in_condition = false
+
+    File.readlines(file).each do |line|
+      in_condition = true if line.strip.start_with?("if")
+      in_condition = false if line.strip == "end"
+
+      next if in_condition
+
+      line.match(/config\.[a-zA-Z_]+ = /) do |match|
+        property = match[0]
+        if properties.include?(property)
+          puts "#{file}: #{line}"
+        else
+          properties << property
+        end
+      end
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  Dir.chdir(ARGV[0]) do
+    ensure_no_duplicate_config_lines_in_environment_files
+  end
+end

--- a/variants/backend-base/config/environments/development.rb
+++ b/variants/backend-base/config/environments/development.rb
@@ -1,19 +1,18 @@
-mailer_regex = /config\.action_mailer\.raise_delivery_errors = false\n/
-
-comment_lines "config/environments/development.rb", mailer_regex
-insert_into_file! "config/environments/development.rb", after: mailer_regex do
-  <<-RUBY
-
+gsub_file! "config/environments/development.rb",
+           <<-RUBY,
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = false
+RUBY
+           <<-RUBY
   # Ensure mailer works in development.
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: "localhost:3000" }
   config.action_mailer.asset_host = "http://localhost:3000"
+RUBY
 
-  # Raise an error if we try and look up a missing translation
-  config.i18n.raise_on_missing_translations = true
-  RUBY
-end
+gsub_file! "config/environments/development.rb",
+           "# config.i18n.raise_on_missing_translations = true",
+           "config.i18n.raise_on_missing_translations = true"
 
 gsub_file! "config/environments/development.rb",
            "config.action_controller.raise_on_missing_callback_actions = true",

--- a/variants/backend-base/config/environments/production.rb
+++ b/variants/backend-base/config/environments/production.rb
@@ -17,12 +17,11 @@ gsub_file! "config/environments/production.rb",
              config.force_ssl = ENV.fetch("RAILS_FORCE_SSL", "true").downcase != "false"
            RUBY
 
-insert_into_file! "config/environments/production.rb",
-                  after: /# config\.action_mailer\.raise_deliv.*\n/ do
-  <<-RUBY
-
-  # Production email config
+gsub_file! "config/environments/production.rb",
+           "# config.action_mailer.raise_delivery_errors = false",
+           <<-RUBY
   config.action_mailer.raise_delivery_errors = true
+
   config.action_mailer.default_url_options = {
     host: "#{TEMPLATE_CONFIG.production_hostname}",
     protocol: "https"
@@ -38,9 +37,7 @@ insert_into_file! "config/environments/production.rb",
     authentication: "login",
     domain: "#{TEMPLATE_CONFIG.production_hostname}"
   }
-
-  RUBY
-end
+RUBY
 
 gsub_file! "config/environments/production.rb",
            'ENV.fetch("RAILS_LOG_LEVEL", "info")',

--- a/variants/backend-base/config/environments/test.rb
+++ b/variants/backend-base/config/environments/test.rb
@@ -5,13 +5,17 @@ insert_into_file! \
 
   # Ensure mailer works in test
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: "localhost:3000" }
   config.action_mailer.asset_host = "http://localhost:3000"
-
-  # Raise an error if we try and look up a missing translation
-  config.i18n.raise_on_missing_translations = true
   RUBY
 end
+
+gsub_file! "config/environments/test.rb",
+           'config.action_mailer.default_url_options = { host: "www.example.com" }',
+           'config.action_mailer.default_url_options = { host: "localhost:3000" }'
+
+gsub_file! "config/environments/test.rb",
+           "# config.i18n.raise_on_missing_translations = true",
+           "config.i18n.raise_on_missing_translations = true"
 
 gsub_file! "config/environments/test.rb",
            "config.action_controller.raise_on_missing_callback_actions = true",


### PR DESCRIPTION
This should make it easier to see changes when upgrading Rails and just generally make things abit cleaner by reducing the amount of code we've got