### PR TITLE
fix: use the latest major versions of Shakapacker peer dependencies

### DIFF
--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -18,24 +18,17 @@ package_json.record_package_manager!
 
 run "rails shakapacker:install"
 
-peers = JSON.load_file("node_modules/shakapacker/package.json").fetch("peerDependencies", {})
-dev_dependency_packages = ["webpack-dev-server"]
-dependencies_to_add = []
-dev_dependencies_to_add = []
-
-peers.each do |(package, version)|
-  major_version = version.split("||").last.match(/(\d+)/)[1]
-  entry = "#{package}@#{major_version}"
-
-  if dev_dependency_packages.include? package
-    dev_dependencies_to_add << entry
-  else
-    dependencies_to_add << entry
-  end
-end
-
-yarn_add_dependencies(dependencies_to_add)
-yarn_add_dev_dependencies(dev_dependencies_to_add)
+# ensure the latest major versions of Shakapacker's peer dependencies are installed
+#
+# TODO: remove this once https://github.com/shakacode/shakapacker/pull/576 is landed
+yarn_add_dependencies [
+  "babel-loader@10",
+  "compression-webpack-plugin@11",
+  "webpack-assets-manifest@6",
+  "webpack-cli@6",
+  "webpack-merge@6"
+]
+yarn_add_dev_dependencies ["webpack-dev-server@5"]
 
 # this is added by shakapacker:install, but we've already got one (with some extra tags)
 # in our template, so remove theirs otherwise the app will error when rendering this


### PR DESCRIPTION
Currently Shakapacker installs the lowest supported major version of its peer dependencies, which isn't ideal since new apps are usually the most guaranteed compatible with latest versions, and also right now this means we're pulling in a version of `webpack-dev-server` with a known vulnerability.

I have created a PR upstream to address this which will hopefully get merged and released, but in the meantime this gets our CI happy