### PR TITLE
refactor: rename methods for adding js dependencies to be more generic

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -385,20 +385,11 @@ end
 # appropriate package manager
 #
 # @param [Array<String>] packages
-def add_js_dependencies(packages)
-  puts "adding #{packages.join(" ")} as dependencies"
+# @param [:production, :dev] type
+def add_js_dependencies(packages, type: :production)
+  puts "adding #{packages.join(" ")} as #{type} dependencies"
 
-  package_json.manager.add!(packages)
-end
-
-# Adds the given JavaScript <code>packages</code> as devDependencies using the
-# appropriate package manager
-#
-# @param [Array<String>] packages
-def add_js_dev_dependencies(packages)
-  puts "adding #{packages.join(" ")} as dev dependencies"
-
-  package_json.manager.add!(packages, type: :dev)
+  package_json.manager.add!(packages, type:)
 end
 
 # Add this template directory to source_paths so that Thor actions like

--- a/template.rb
+++ b/template.rb
@@ -381,19 +381,21 @@ def cleanup_package_json
   package_json.manager.install!
 end
 
-# Adds the given <code>packages</code> as dependencies using <code>yarn add</code>
+# Adds the given JavaScript <code>packages</code> as dependencies using the
+# appropriate package manager
 #
 # @param [Array<String>] packages
-def yarn_add_dependencies(packages)
+def add_js_dependencies(packages)
   puts "adding #{packages.join(" ")} as dependencies"
 
   package_json.manager.add!(packages)
 end
 
-# Adds the given <code>packages</code> as devDependencies using <code>yarn add --dev</code>
+# Adds the given JavaScript <code>packages</code> as devDependencies using the
+# appropriate package manager
 #
 # @param [Array<String>] packages
-def yarn_add_dev_dependencies(packages)
+def add_js_dev_dependencies(packages)
   puts "adding #{packages.join(" ")} as dev dependencies"
 
   package_json.manager.add!(packages, type: :dev)

--- a/variants/accessibility/template.rb
+++ b/variants/accessibility/template.rb
@@ -5,4 +5,4 @@ apply "spec/rails_helper.rb"
 apply "spec/system/home_feature_spec.rb"
 copy_file "spec/support/shared_examples/an_accessible_page.rb"
 
-add_js_dev_dependencies %w[lighthouse]
+add_js_dependencies %w[lighthouse], type: :dev

--- a/variants/accessibility/template.rb
+++ b/variants/accessibility/template.rb
@@ -5,4 +5,4 @@ apply "spec/rails_helper.rb"
 apply "spec/system/home_feature_spec.rb"
 copy_file "spec/support/shared_examples/an_accessible_page.rb"
 
-yarn_add_dev_dependencies %w[lighthouse]
+add_js_dev_dependencies %w[lighthouse]

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -23,11 +23,11 @@ types_packages = %w[
 ].map { |name| "@types/#{name}" }
 
 add_js_dependencies types_packages + %w[@babel/preset-typescript typescript]
-add_js_dev_dependencies %w[
+add_js_dependencies %w[
   @stylistic/eslint-plugin-ts@3
   @typescript-eslint/eslint-plugin
   @typescript-eslint/parser
-]
+], type: :dev
 
 package_json.manager.remove!(["globals"])
 

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -22,8 +22,8 @@ types_packages = %w[
   node@18
 ].map { |name| "@types/#{name}" }
 
-yarn_add_dependencies types_packages + %w[@babel/preset-typescript typescript]
-yarn_add_dev_dependencies %w[
+add_js_dependencies types_packages + %w[@babel/preset-typescript typescript]
+add_js_dev_dependencies %w[
   @stylistic/eslint-plugin-ts@3
   @typescript-eslint/eslint-plugin
   @typescript-eslint/parser

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -3,7 +3,7 @@
 
 add_yarn_package_extension_dependency("eslint-plugin-prettier", "eslint-config-prettier")
 
-yarn_add_dev_dependencies %w[
+add_js_dev_dependencies %w[
   @eslint-community/eslint-plugin-eslint-comments
   @stylistic/eslint-plugin-js@3
   @eslint/js
@@ -57,7 +57,7 @@ append_to_file! "bin/ci-run" do
 end
 
 # SCSS Linting
-yarn_add_dev_dependencies %w[
+add_js_dev_dependencies %w[
   postcss
   stylelint
   stylelint-scss

--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -3,7 +3,7 @@
 
 add_yarn_package_extension_dependency("eslint-plugin-prettier", "eslint-config-prettier")
 
-add_js_dev_dependencies %w[
+add_js_dependencies %w[
   @eslint-community/eslint-plugin-eslint-comments
   @stylistic/eslint-plugin-js@3
   @eslint/js
@@ -16,7 +16,7 @@ add_js_dev_dependencies %w[
   prettier
   prettier-config-ackama
   prettier-plugin-packagejson
-]
+], type: :dev
 
 copy_file "variants/frontend-base/eslint.config.js", "eslint.config.js"
 template "variants/frontend-base/.prettierignore.tt", ".prettierignore"
@@ -57,12 +57,12 @@ append_to_file! "bin/ci-run" do
 end
 
 # SCSS Linting
-add_js_dev_dependencies %w[
+add_js_dependencies %w[
   postcss
   stylelint
   stylelint-scss
   stylelint-config-recommended-scss
-]
+], type: :dev
 copy_file "variants/frontend-base/.stylelintrc.js", ".stylelintrc.js"
 template "variants/frontend-base/.stylelintignore.tt", ".stylelintignore"
 

--- a/variants/frontend-base/sentry/template.rb
+++ b/variants/frontend-base/sentry/template.rb
@@ -1,7 +1,7 @@
 # Setup Sentry
 # ############
 
-yarn_add_dependencies %w[@sentry/browser dotenv-webpack]
+add_js_dependencies %w[@sentry/browser dotenv-webpack]
 
 prepend_to_file! "app/frontend/packs/application.js", "import * as Sentry from '@sentry/browser';"
 

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -21,14 +21,14 @@ run "rails shakapacker:install"
 # ensure the latest major versions of Shakapacker's peer dependencies are installed
 #
 # TODO: remove this once https://github.com/shakacode/shakapacker/pull/576 is landed
-yarn_add_dependencies [
+add_js_dependencies [
   "babel-loader@10",
   "compression-webpack-plugin@11",
   "webpack-assets-manifest@6",
   "webpack-cli@6",
   "webpack-merge@6"
 ]
-yarn_add_dev_dependencies ["webpack-dev-server@5"]
+add_js_dev_dependencies ["webpack-dev-server@5"]
 
 # this is added by shakapacker:install, but we've already got one (with some extra tags)
 # in our template, so remove theirs otherwise the app will error when rendering this
@@ -107,7 +107,7 @@ EO_IMG_EXAMPLE
 gsub_file! "app/views/layouts/application.html.erb", "<body>", body_open_tag_with_img_example, force: true
 
 # shakapacker will automatically configure webpack to use these so long as the dependencies are present
-yarn_add_dependencies %w[
+add_js_dependencies %w[
   css-loader
   css-minimizer-webpack-plugin
   mini-css-extract-plugin
@@ -116,7 +116,7 @@ yarn_add_dependencies %w[
 ]
 
 # Setup Turbo
-yarn_add_dependencies %w[
+add_js_dependencies %w[
   @hotwired/turbo-rails
 ]
 prepend_to_file! "app/frontend/packs/application.js" do

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -28,7 +28,7 @@ add_js_dependencies [
   "webpack-cli@6",
   "webpack-merge@6"
 ]
-add_js_dev_dependencies ["webpack-dev-server@5"]
+add_js_dependencies ["webpack-dev-server@5"], type: :dev
 
 # this is added by shakapacker:install, but we've already got one (with some extra tags)
 # in our template, so remove theirs otherwise the app will error when rendering this

--- a/variants/frontend-bootstrap-typescript/template.rb
+++ b/variants/frontend-bootstrap-typescript/template.rb
@@ -1,5 +1,5 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-yarn_add_dependencies %w[@types/bootstrap]
+add_js_dependencies %w[@types/bootstrap]
 
 rename_js_file_to_ts "app/frontend/js/bootstrap"

--- a/variants/frontend-bootstrap/template.rb
+++ b/variants/frontend-bootstrap/template.rb
@@ -1,6 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-yarn_add_dependencies(["bootstrap", "@popperjs/core"])
+add_js_dependencies(["bootstrap", "@popperjs/core"])
 
 copy_file "app/frontend/js/bootstrap.js", force: true
 insert_into_file! "app/frontend/packs/application.js", "import '../js/bootstrap';", before: 'import "../stylesheets/application.scss";'

--- a/variants/frontend-react-typescript/template.rb
+++ b/variants/frontend-react-typescript/template.rb
@@ -1,7 +1,7 @@
 source_paths.unshift(File.dirname(__FILE__))
 
 package_json.manager.remove!(["prop-types"])
-yarn_add_dependencies %w[@types/react @types/react-dom]
+add_js_dependencies %w[@types/react @types/react-dom]
 
 rename_js_file_to_ts "app/frontend/packs/server_rendering"
 

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -22,12 +22,12 @@ add_js_dependencies %w[
   prop-types
 ]
 
-add_js_dev_dependencies %w[
+add_js_dependencies %w[
   @testing-library/react
   eslint-plugin-react
   eslint-plugin-react-hooks
   eslint-plugin-jsx-a11y
-]
+], type: :dev
 copy_file "eslint.config.js", force: true
 copy_file "babel.config.js", force: true
 

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -14,7 +14,7 @@ gsub_file! "app/frontend/test/stimulus/controllers/add_class_controller.test.js"
            "'@testing-library/dom'",
            "'@testing-library/react'"
 
-yarn_add_dependencies %w[
+add_js_dependencies %w[
   @babel/preset-react
   babel-plugin-transform-react-remove-prop-types
   react
@@ -22,7 +22,7 @@ yarn_add_dependencies %w[
   prop-types
 ]
 
-yarn_add_dev_dependencies %w[
+add_js_dev_dependencies %w[
   @testing-library/react
   eslint-plugin-react
   eslint-plugin-react-hooks

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -8,8 +8,8 @@ add_yarn_package_extension_dependency("@jest/test-result", "jest-haste-map")
 add_yarn_package_extension_dependency("@jest/test-result", "jest-resolve")
 add_yarn_package_extension_dependency("jest-cli", "@types/yargs")
 
-yarn_add_dependencies ["@babel/plugin-transform-typescript"]
-yarn_add_dev_dependencies [
+add_js_dependencies ["@babel/plugin-transform-typescript"]
+add_js_dev_dependencies [
   "@types/jest@#{JEST_MAJOR_VERSION}",
   "ts-jest@#{JEST_MAJOR_VERSION}",
   "ts-node"

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -9,11 +9,11 @@ add_yarn_package_extension_dependency("@jest/test-result", "jest-resolve")
 add_yarn_package_extension_dependency("jest-cli", "@types/yargs")
 
 add_js_dependencies ["@babel/plugin-transform-typescript"]
-add_js_dev_dependencies [
+add_js_dependencies [
   "@types/jest@#{JEST_MAJOR_VERSION}",
   "ts-jest@#{JEST_MAJOR_VERSION}",
   "ts-node"
-]
+], type: :dev
 
 copy_file "eslint.config.js", force: true
 

--- a/variants/frontend-stimulus/template.rb
+++ b/variants/frontend-stimulus/template.rb
@@ -46,7 +46,7 @@ append_to_file! "app/frontend/packs/application.js" do
   EO_JS_SETUP
 end
 
-add_js_dev_dependencies %W[
+add_js_dependencies %W[
   @testing-library/dom
   @testing-library/jest-dom
   @testing-library/user-event
@@ -56,7 +56,7 @@ add_js_dev_dependencies %W[
   eslint-plugin-testing-library
   jest-environment-jsdom
   jest@#{JEST_MAJOR_VERSION}
-]
+], type: :dev
 
 copy_file "eslint.config.js", force: true
 copy_file "jest.config.js"

--- a/variants/frontend-stimulus/template.rb
+++ b/variants/frontend-stimulus/template.rb
@@ -2,7 +2,7 @@ source_paths.unshift(File.dirname(__FILE__))
 
 TERMINAL.puts_header "Setting up stimulus.js"
 
-yarn_add_dependencies %w[
+add_js_dependencies %w[
   @hotwired/stimulus
   @hotwired/stimulus-webpack-helpers
 ]
@@ -46,7 +46,7 @@ append_to_file! "app/frontend/packs/application.js" do
   EO_JS_SETUP
 end
 
-yarn_add_dev_dependencies %W[
+add_js_dev_dependencies %W[
   @testing-library/dom
   @testing-library/jest-dom
   @testing-library/user-event


### PR DESCRIPTION
It's not longer a given that `yarn` is being used, and ultimately we're planning to switch to NPM so might as well change the method names now