### PR TITLE
fix: don't exclude `doc/**/*` and `config/initializers/version.rb` from rubocops wrath

### DIFF
--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -24,15 +24,12 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:
-    - 'bin/*'
-    - config/initializers/version.rb
     - db/schema.rb
     - 'node_modules/**/*'
     - 'bower_components/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'bin/**/*'
-    - 'doc/**/*'
 
 Layout/LineLength:
   Max: 120

--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -26,7 +26,6 @@ AllCops:
   Exclude:
     - db/schema.rb
     - 'node_modules/**/*'
-    - 'bower_components/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'bin/**/*'


### PR DESCRIPTION
This started as just removing the `bin/*` since we've already got `bin/**/*` but I don't see a reason for us to exclude `doc/**/*` and `config/initializers/version.rb` 🤷

Ideally we should also include `bin/setup` but it doesn't seem like you can easily have Rubocop (re)include a single file so have left that for now