### PR TITLE
fix: reuse Capybara chrome instance for lighthouse audits

### DIFF
--- a/variants/accessibility/spec/rails_helper.rb
+++ b/variants/accessibility/spec/rails_helper.rb
@@ -10,5 +10,6 @@ insert_into_file! "spec/rails_helper.rb", after: /# Add other Chrome arguments h
     # Lighthouse Matcher options
     options.add_argument("--remote-debugging-port=9222")
     Lighthouse::Matchers.chrome_flags = %w[headless=new no-sandbox]
+    Lighthouse::Matchers.remote_debugging_port = 9222
   OPTIONS
 end


### PR DESCRIPTION
Right now we actually spin up a whole new instance of Chrome when running lighthouse tests which besides being costly also means that none of our presetup work such as logging users in happens 😬 