### PR TITLE
ci: ensure global Ruby gems directory has the right permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,12 @@ jobs:
           bundler-cache: true
           ruby-version: 'ruby'
 
+      # ensure the global Ruby gem directory is secure, as versions of Ruby that ship "cached"
+      # with the GHA runner seem to have the permissions set incorrectly, unlike when they're
+      # installed via ruby/setup-ruby (which isn't something we can force)
+      # see https://github.com/rubygems/rubygems/issues/7983
+      - run: chmod -R o-w /opt/hostedtoolcache/Ruby
+
       - name: Setup git for committing
         run: |
           # We do some git commits during our testing so these need to be set


### PR DESCRIPTION
This looks to have come about because [the current latest release of the Ubuntu 24.04 image](https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250804.2) happens to include the version of Ruby we're using as a cached version, so `ruby/setup-ruby` is no longer installing Ruby.

From what I've seen I believe this only impacts the template due to using `bundler/inline` which is a bit exotic - it shouldn't happen in other CIs or locally