### PR TITLE
feat: have Rubocop always enforce shorthand hash syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -190,6 +190,9 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
 # https://rubocop.readthedocs.io/en/latest/cops_style/
 Style/HashTransformKeys:
   Enabled: false

--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -210,6 +210,9 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
 # https://rubocop.readthedocs.io/en/latest/cops_style/
 Style/HashTransformKeys:
   Enabled: false


### PR DESCRIPTION
This was the default since Ruby 3.1 but turns out a year ago [they changed it to "either"](https://github.com/rubocop/rubocop/pull/13300) - since we already decided we're in favor of using this syntax when the rule originally came out, and I don't think there's any value in using it conditionally, this has Rubocop enforce it again