### PR TITLE
feat: have ci capture capybara screenshots and lighthouse results in rspec output artifact

### DIFF
--- a/variants/accessibility/spec/rails_helper.rb
+++ b/variants/accessibility/spec/rails_helper.rb
@@ -10,5 +10,6 @@ insert_into_file! "spec/rails_helper.rb", after: /# Add other Chrome arguments h
     # Lighthouse Matcher options
     options.add_argument("--remote-debugging-port=9222")
     Lighthouse::Matchers.chrome_flags = %w[headless=new no-sandbox]
+    Lighthouse::Matchers.results_directory = Rails.root.join("tmp/lighthouse")
   OPTIONS
 end

--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -116,8 +116,11 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: rspec-output-screenshots
-          path: tmp/screenshots
+          name: rspec-output-results
+          path: |
+            tmp/capybara
+            tmp/screenshots
+            tmp/lighthouse
           retention-days: 5
 
   # ACTION REQUIRED:


### PR DESCRIPTION
The newest version of [`lighthouse-matchers` has audit results written to disk](https://github.com/ackama/lighthouse-matchers/pull/68) to make it easier to debug why a score was lower than expected, so this has our standard CI capture those in the rspec output artifacts, along with capybara screenshots