### PR TITLE
fix: use `Rails.env` if `SENTRY_ENV` is an empty string

### DIFF
--- a/variants/backend-base/config/initializers/sentry.rb
+++ b/variants/backend-base/config/initializers/sentry.rb
@@ -8,7 +8,7 @@ Sentry.init do |config|
   config.dsn = ENV.fetch("SENTRY_DSN", nil)
 
   # Set Sentry environment to be current environment if SENTRY_ENV is not set
-  config.environment = ENV.fetch("SENTRY_ENV", Rails.env)
+  config.environment = ENV["SENTRY_ENV"].presence || Rails.env
 
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 


### PR DESCRIPTION
This should be more flexible since some environments such as ECS error if an environment variable is defined without any value, which causes `ENV.fetch` to return an empty string rather than fall back to our default value