### PR TITLE
feat(github): ensure there are no unused routes

### DIFF
--- a/variants/github_actions_ci/workflows/ci.yml.tt
+++ b/variants/github_actions_ci/workflows/ci.yml.tt
@@ -107,6 +107,7 @@ jobs:
       - run: bundle exec erb_lint .
       - run: bundle exec brakeman --run-all-checks .
       - run: bundle exec rails db:setup
+      - run: bundle exec rails routes --unused
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'


### PR DESCRIPTION
An "unused route" in this context is a route that is defined but whose controller does not actually have a method for that route, meaning if it gets called a 500 will be thrown - not the end of the world, but easily avoided by using `except` and `only` when defining the route.