### PR TITLE
fix: lock `eslint-plugin-n` to v17

### DIFF
--- a/variants/frontend-base/js-lint/template.rb
+++ b/variants/frontend-base/js-lint/template.rb
@@ -7,7 +7,7 @@ add_js_dependencies %w[
   @eslint/js@9
   eslint@9
   eslint-config-ackama
-  eslint-plugin-n
+  eslint-plugin-n@17
   eslint-plugin-import
   eslint-plugin-prettier
   globals


### PR DESCRIPTION
We're not ready use to support v18