### PR TITLE
fix: pin TypeScript to v5

### DIFF
--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -21,7 +21,7 @@ types_packages = %w[
   node@24
 ].map { |name| "@types/#{name}" }
 
-add_js_dependencies types_packages + %w[@babel/preset-typescript typescript]
+add_js_dependencies types_packages + %w[@babel/preset-typescript typescript@5]
 add_js_dependencies %w[
   @stylistic/eslint-plugin-ts@3
   @typescript-eslint/eslint-plugin


### PR DESCRIPTION
I'm working on updating things for v6 but for now I'd just like a green CI