### PR TITLE
feat: drop `ts-node` in favor of native typestripping

### DIFF
--- a/variants/frontend-stimulus-typescript/jest.config.ts
+++ b/variants/frontend-stimulus-typescript/jest.config.ts
@@ -1,4 +1,4 @@
-import { Config } from 'jest';
+import type { Config } from 'jest';
 
 const config: Config = {
   testEnvironment: 'jsdom',

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -1,10 +1,7 @@
 source_paths.unshift(File.dirname(__FILE__))
 
 add_js_dependencies ["@babel/plugin-transform-typescript"]
-add_js_dependencies [
-  "@types/jest@#{JEST_MAJOR_VERSION}",
-  "ts-node"
-], type: :dev
+add_js_dependencies ["@types/jest@#{JEST_MAJOR_VERSION}"], type: :dev
 
 copy_file "eslint.config.js", force: true
 


### PR DESCRIPTION
Node has had native typestripping for a while now and latest Jest supports using that rather than `ts-node` to load its config, so we no longer need this dependency