### PR TITLE
chore: ignore `uuid` vulnerability

### DIFF
--- a/variants/backend-base/.osv-detector.yml
+++ b/variants/backend-base/.osv-detector.yml
@@ -1,1 +1,2 @@
-ignore: []
+ignore:
+  - GHSA-w5hq-g745-h8pq # uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided


### PR DESCRIPTION
This vulnerability is not exploitable since it does not impact the v4 generator which is what `sockjs` is using it for; [hopefully they'll release a new version soon](https://github.com/sockjs/sockjs-node/issues/316) which'll make this go away, or that [`webpack-dev-server`](https://github.com/webpack/webpack-dev-server/issues/5662) will release their new major soon that drops `sockjs` support, but in the meantime we have to ignore this