### PR TITLE
fix: allow annotate comments to be of any length

### DIFF
--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -32,6 +32,9 @@ AllCops:
 
 Layout/LineLength:
   Max: 120
+  AllowedPatterns:
+    - '# @route \w+ /.+' # allow controller route annotations to be any length
+    - '#  index_\w+ +\(.+\) [A-Z ]+ \([\w ]+\)' # allow model index annotations to be any length
   Exclude:
     - 'config/**/*'
     - 'db/**/*'


### PR DESCRIPTION
I've included this in a few codebases now and it seems to be working well - I don't think we should be trying to do anything differently given they're generated as we'd have to manually reformat the lines every time