### PR TITLE
fix(sentry): coerce SENTRY_TRACES_SAMPLE_RATE to Float

### DIFF
--- a/variants/backend-base/config/initializers/sentry.rb
+++ b/variants/backend-base/config/initializers/sentry.rb
@@ -13,5 +13,5 @@ Sentry.init do |config|
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
   # To activate performance monitoring, use the environment variable
-  config.traces_sample_rate = ENV.fetch("SENTRY_TRACES_SAMPLE_RATE", 0)
+  config.traces_sample_rate = ENV.fetch("SENTRY_TRACES_SAMPLE_RATE", 0).to_f
 end


### PR DESCRIPTION
`ENV.fetch` returns a `String` when the environment variable is set, which sentry-ruby's `valid_sample_rate?` rejects, since it requires a `Numeric`, silently disabling tracing.

This PR coerces with `.to_f` so that the environment variable actually takes effect.