### PR TITLE
chore: sort rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,12 +10,6 @@ plugins:
   - rubocop-rspec
   - rubocop-rspec_rails
 
-# Built-in config:
-# https://github.com/bbatsov/rubocop/blob/master/config/default.yml
-
-Rails:
-  Enabled: true
-
 AllCops:
   # Target the oldest Ruby that this template's chosen Rails version supports In
   # a normal Rails app, Rubocop would infer this from the version of Ruby
@@ -26,7 +20,6 @@ AllCops:
     <%=
     YAML.safe_load(Pathname.new("./target_versions.yml").realpath.read).fetch("minimum_ruby_major_minor")
     %>
-
   # In a normal Rails app, Rubocop would pull this from the Gemfile. We want the
   # rubocop checks that run on this repo to be consistent with the checks that
   # run on generated apps so we have to be explicit.
@@ -34,7 +27,6 @@ AllCops:
     <%=
     YAML.safe_load(Pathname.new("./target_versions.yml").realpath.read).fetch("target_rails_major_minor")
     %>
-
   NewCops: enable
   DisplayCopNames: true
   DisplayStyleGuide: true
@@ -43,31 +35,13 @@ AllCops:
     - 'vendor/**/*'
     - 'node_modules/**/*'
 
-Style/Documentation:
+FactoryBot/SyntaxMethods:
   Enabled: false
 
-Layout/LineLength:
-  Max: 200
-
-Metrics/BlockLength:
-  Max: 50
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Metrics/MethodLength:
-  Max: 50
-
-# This cop complains when you have variables named things like:
-#     address_line_1
-#     address_line_2
-# etc.
-Naming/VariableNumber:
-  Enabled: false
-
-# Just always use `raise` and stop thinking about it.
-Style/SignalException:
-  EnforcedStyle: only_raise
+# We want you to put a blank line between method definitions, the only exception being
+# if you're defining a bunch of single-line methods as above.
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
 
 # We think that:
 #   array = [
@@ -103,6 +77,9 @@ Layout/FirstArrayElementIndentation:
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
+Layout/LineLength:
+  Max: 200
+
 # We think that:
 #     {
 #       foo: :bar
@@ -125,38 +102,127 @@ Layout/MultilineHashBraceLayout:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
-# Just always use double quotes and stop thinking about it.
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
+# This syntax is a deliberate idiom in rspec
+# bbatsov endorses disabling it for rspec
+# https://github.com/bbatsov/rubocop/issues/4222#issuecomment-290722962
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
 
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
+Metrics/AbcSize:
+  Max: 18
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/BlockLength:
+  Max: 50
+
+Metrics/ClassLength:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/MethodLength:
+  Max: 50
+
+Naming/FileName:
+  Exclude:
+    - '**/Gemfile.rb'
+    - '**/Rakefile.rb'
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
+# This cop complains when you have variables named things like:
+#     address_line_1
+#     address_line_2
+# etc.
+Naming/VariableNumber:
+  Enabled: false
+
+Performance/Casecmp:
+  Enabled: false
+
+RSpec:
+  Language:
+    Expectations:
+      - assert_match
+
+RSpec/ExampleLength:
+  Max: 30
+
+RSpec/MultipleExpectations:
+  Max: 10
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/RepeatedExample:
+  Exclude:
+    - 'variants/pundit/spec/policies/**'
+
+Rails:
+  Enabled: true
+
+Rails/ApplicationRecord:
+  Exclude:
+    - 'db/migrate/**'
+
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - 'app/controllers/application_controller.rb'
+
+# we don't require using Rails.logger in lib, as it often doesn't go where
+# we'd want for the code that lives there, or otherwise isn't even available
+Rails/Output:
+  Exclude:
+    - 'lib/**/*'
+
+Rails/SquishedSQLHeredocs:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+Style/Documentation:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+# Ruby supports two styles of string template formatting.
+# "annotated" - format("%<greeting>s", greeting: "Hello")
+# "template"  - format("%{greeting}", greeting: "Hello")
+#
+# While the annotated format is more descriptive, it also comes in a style that is
+# significantly harder for a developer to parse. The template style is easy to read, understand,
+# and is consistent with formatting with (for example), interpolation (#{}).
+Style/FormatStringToken:
+  EnforcedStyle: template
 
 # Ruby 2.4+ has a magic comment that makes all strings frozen and Rubocop wants to put it
 # at the top of every. single. file. We decided we didn't want that - for now.
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-# Single line method definitions are totally fine, and often more readable, consider:
-#    class WidgetsPolicy
-#      def create?; false; end
-#      def index?;  true;  end
-#      def show?;   true;  end
-#      def update?; false; end
-#      def delete?; false; end
-#    end
-Style/SingleLineMethods:
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/
+Style/HashTransformKeys:
   Enabled: false
 
-# We want you to put a blank line between method definitions, the only exception being
-# if you're defining a bunch of single-line methods as above.
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
+# https://rubocop.readthedocs.io/en/latest/cops_style/
+Style/HashTransformValues:
+  Enabled: false
 
-Naming/FileName:
-  Exclude:
-    - '**/Gemfile.rb'
-    - '**/Rakefile.rb'
+Style/NumericPredicate:
+  Enabled: false
 
 # Disable preference for Ruby's new safe navigation operator `&.` because it
 # usually comes at the cost of expressiveness in the simple case:
@@ -173,98 +239,27 @@ Naming/FileName:
 Style/SafeNavigation:
   Enabled: false
 
-# Ruby supports two styles of string template formatting.
-# "annotated" - format("%<greeting>s", greeting: "Hello")
-# "template"  - format("%{greeting}", greeting: "Hello")
-#
-# While the annotated format is more descriptive, it also comes in a style that is
-# significantly harder for a developer to parse. The template style is easy to read, understand,
-# and is consistent with formatting with (for example), interpolation (#{}).
-Style/FormatStringToken:
-  EnforcedStyle: template
+# Just always use `raise` and stop thinking about it.
+Style/SignalException:
+  EnforcedStyle: only_raise
 
-# This syntax is a deliberate idiom in rspec
-# bbatsov endorses disabling it for rspec
-# https://github.com/bbatsov/rubocop/issues/4222#issuecomment-290722962
-Lint/AmbiguousBlockAssociation:
-  Exclude:
-    - 'spec/**/*'
-
-Style/HashSyntax:
-  EnforcedShorthandSyntax: always
-
-# https://rubocop.readthedocs.io/en/latest/cops_style/
-Style/HashTransformKeys:
+# Single line method definitions are totally fine, and often more readable, consider:
+#    class WidgetsPolicy
+#      def create?; false; end
+#      def index?;  true;  end
+#      def show?;   true;  end
+#      def update?; false; end
+#      def delete?; false; end
+#    end
+Style/SingleLineMethods:
   Enabled: false
 
-# https://rubocop.readthedocs.io/en/latest/cops_style/
-Style/HashTransformValues:
-  Enabled: false
+# Just always use double quotes and stop thinking about it.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
 
-Metrics/AbcSize:
-  Max: 18
-  Exclude:
-    - 'spec/**/*'
-
-Metrics/ClassLength:
-  Exclude:
-    - 'spec/**/*'
-
-Naming/MemoizedInstanceVariableName:
-  EnforcedStyleForLeadingUnderscores: optional
-
-Performance/Casecmp:
-  Enabled: false
-
-Rails/ApplicationRecord:
-  Exclude:
-    - 'db/migrate/**'
-
-# we don't require using Rails.logger in lib, as it often doesn't go where
-# we'd want for the code that lives there, or otherwise isn't even available
-Rails/Output:
-  Exclude:
-    - 'lib/**/*'
-
-Style/BarePercentLiterals:
-  EnforcedStyle: percent_q
-
-Style/DoubleNegation:
-  Enabled: false
-
-Style/EmptyMethod:
-  Enabled: false
-
-Style/NumericPredicate:
-  Enabled: false
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
 
 Style/TrivialAccessors:
   AllowPredicates: true
-
-RSpec:
-  Language:
-    Expectations:
-      - assert_match
-
-RSpec/MultipleExpectations:
-  Max: 10
-
-RSpec/ExampleLength:
-  Max: 30
-
-Rails/LexicallyScopedActionFilter:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-
-RSpec/RepeatedExample:
-  Exclude:
-    - 'variants/pundit/spec/policies/**'
-
-RSpec/MultipleMemoizedHelpers:
-  Max: 10
-
-FactoryBot/SyntaxMethods:
-  Enabled: false
-
-Rails/SquishedSQLHeredocs:
-  Enabled: false

--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -7,18 +7,6 @@ plugins:
   - rubocop-rspec
   - rubocop-rspec_rails
 
-# Built-in config:
-# https://github.com/bbatsov/rubocop/blob/master/config/default.yml
-
-# We do not typically use/need class documentation
-Style/Documentation:
-  Enabled: false
-
-# Run rails specific checks
-# https://github.com/bbatsov/rubocop#rails
-Rails:
-  Enabled: true
-
 AllCops:
   NewCops: enable
   DisplayCopNames: true
@@ -30,60 +18,13 @@ AllCops:
     - 'vendor/**/*'
     - 'bin/**/*'
 
-Layout/LineLength:
-  Max: 120
-  AllowedPatterns:
-    - '# @route \w+ /.+' # allow controller route annotations to be any length
-    - '#  index_\w+ +\(.+\) [A-Z ]+ \([\w ]+\)' # allow model index annotations to be any length
-  Exclude:
-    - 'config/**/*'
-    - 'db/**/*'
-
-Metrics/ModuleLength:
-  Exclude:
-    - 'spec/**/*_spec.rb'
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*.rb'
-    - 'config/**/*'
-    - 'lib/tasks/**/*'
-
-# We generally don't want methods longer than 20 lines, except in migrations where it's probably okay.
-Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - 'db/migrate/**/*.rb'
-    - 'spec/**/*'
-
-# Rubocop doesn't like methods that start with `get_` or `set_`, however sometimes this is unavoidable
-# when writing pundit policies (especially where jsonapi-resources is involved).
-Naming/AccessorMethodName:
-  Exclude:
-    - 'app/policies/**/*_policy.rb'
-
-# Rubocop doesn't like using `post("/", {}, {})` and instead wants to use the keyword variant of these
-# methods, but often brevity is more important than readability in specs.
-Rails/HttpPositionalArguments:
-  Exclude:
-    - 'spec/requests/**/*_spec.rb'
-
-# Rubocop doesn't want us to use any methods which bypass validation in ActiveRecord, but it's quite
-# reasonable to want to do this in a migration.
-Rails/SkipsModelValidations:
-  Exclude:
-    - 'db/migrate/**/*.rb'
-
-# This cop complains when you have variables named things like:
-#     address_line_1
-#     address_line_2
-# etc.
-Naming/VariableNumber:
+FactoryBot/SyntaxMethods:
   Enabled: false
 
-# Just always use `raise` and stop thinking about it.
-Style/SignalException:
-  EnforcedStyle: only_raise
+# We want you to put a blank line between method definitions, the only exception being
+# if you're defining a bunch of single-line methods as above.
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
 
 # We think that:
 #   array = [
@@ -119,6 +60,15 @@ Layout/FirstArrayElementIndentation:
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
+Layout/LineLength:
+  Max: 120
+  AllowedPatterns:
+    - '# @route \w+ /.+' # allow controller route annotations to be any length
+    - '#  index_\w+ +\(.+\) [A-Z ]+ \([\w ]+\)' # allow model index annotations to be any length
+  Exclude:
+    - 'config/**/*'
+    - 'db/**/*'
+
 # We think that:
 #     {
 #       foo: :bar
@@ -141,45 +91,157 @@ Layout/MultilineHashBraceLayout:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
-# Just always use double quotes and stop thinking about it.
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
+# This syntax is a deliberate idiom in rspec
+# bbatsov endorses disabling it for rspec
+# https://github.com/bbatsov/rubocop/issues/4222#issuecomment-290722962
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
 
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
+Metrics/AbcSize:
+  Max: 18
+  Exclude:
+    - 'spec/**/*'
 
-# Ruby 2.4+ has a magic comment that makes all strings frozen and Rubocop wants to put it
-# at the top of every. single. file. We decided we didn't want that - for now.
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-# We usually don't want you to use semicolons in Ruby, except in specs where brevity is
-# often more valued than readability.
-Style/Semicolon:
+Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
+    - 'config/**/*'
+    - 'lib/tasks/**/*'
 
-# Single line method definitions are totally fine, and often more readable, consider:
-#    class WidgetsPolicy
-#      def create?; false; end
-#      def index?;  true;  end
-#      def show?;   true;  end
-#      def update?; false; end
-#      def delete?; false; end
-#    end
-Style/SingleLineMethods:
-  Enabled: false
+Metrics/ClassLength:
+  Exclude:
+    - 'spec/**/*'
 
-# We want you to put a blank line between method definitions, the only exception being
-# if you're defining a bunch of single-line methods as above.
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
+# We generally don't want methods longer than 20 lines, except in migrations where it's probably okay.
+Metrics/MethodLength:
+  Max: 20
+  Exclude:
+    - 'db/migrate/**/*.rb'
+    - 'spec/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+# Rubocop doesn't like methods that start with `get_` or `set_`, however sometimes this is unavoidable
+# when writing pundit policies (especially where jsonapi-resources is involved).
+Naming/AccessorMethodName:
+  Exclude:
+    - 'app/policies/**/*_policy.rb'
 
 Naming/FileName:
   Exclude:
     - '**/Gemfile'
     - '**/Rakefile'
     - '**/Berksfile'
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
+# This cop complains when you have variables named things like:
+#     address_line_1
+#     address_line_2
+# etc.
+Naming/VariableNumber:
+  Enabled: false
+
+Performance/Casecmp:
+  Enabled: false
+
+RSpec:
+  Language:
+    Expectations:
+      - assert_match
+
+RSpec/ExampleLength:
+  Max: 30
+
+RSpec/MultipleExpectations:
+  Max: 10
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/RepeatedExample:
+  Exclude:
+    - 'spec/policies/**'
+
+# Run rails specific checks
+# https://github.com/bbatsov/rubocop#rails
+Rails:
+  Enabled: true
+
+Rails/ApplicationRecord:
+  Exclude:
+    - 'db/migrate/**'
+
+# Rubocop doesn't like using `post("/", {}, {})` and instead wants to use the keyword variant of these
+# methods, but often brevity is more important than readability in specs.
+Rails/HttpPositionalArguments:
+  Exclude:
+    - 'spec/requests/**/*_spec.rb'
+
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - 'app/controllers/application_controller.rb'
+
+# we don't require using Rails.logger in lib, as it often doesn't go where
+# we'd want for the code that lives there, or otherwise isn't even available
+Rails/Output:
+  Exclude:
+    - 'lib/**/*'
+
+# Rubocop doesn't want us to use any methods which bypass validation in ActiveRecord, but it's quite
+# reasonable to want to do this in a migration.
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'db/migrate/**/*.rb'
+
+Rails/SquishedSQLHeredocs:
+  Enabled: false
+
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+# We do not typically use/need class documentation
+Style/Documentation:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+# Ruby supports two styles of string template formatting.
+# "annotated" - format("%<greeting>s", greeting: "Hello")
+# "template"  - format("%{greeting}", greeting: "Hello")
+#
+# While the annotated format is more descriptive, it also comes in a style that is
+# significantly harder for a developer to parse. The template style is easy to read, understand,
+# and is consistent with formatting with (for example), interpolation (#{}).
+Style/FormatStringToken:
+  EnforcedStyle: template
+
+# Ruby 2.4+ has a magic comment that makes all strings frozen and Rubocop wants to put it
+# at the top of every. single. file. We decided we didn't want that - for now.
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/
+Style/HashTransformKeys:
+  Enabled: false
+
+# https://rubocop.readthedocs.io/en/latest/cops_style/
+Style/HashTransformValues:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
 
 # Disable preference for Ruby's new safe navigation operator `&.` because it
 # usually comes at the cost of expressiveness in the simple case:
@@ -196,98 +258,33 @@ Naming/FileName:
 Style/SafeNavigation:
   Enabled: false
 
-# Ruby supports two styles of string template formatting.
-# "annotated" - format("%<greeting>s", greeting: "Hello")
-# "template"  - format("%{greeting}", greeting: "Hello")
-#
-# While the annotated format is more descriptive, it also comes in a style that is
-# significantly harder for a developer to parse. The template style is easy to read, understand,
-# and is consistent with formatting with (for example), interpolation (#{}).
-Style/FormatStringToken:
-  EnforcedStyle: template
-
-# This syntax is a deliberate idiom in rspec
-# bbatsov endorses disabling it for rspec
-# https://github.com/bbatsov/rubocop/issues/4222#issuecomment-290722962
-Lint/AmbiguousBlockAssociation:
+# We usually don't want you to use semicolons in Ruby, except in specs where brevity is
+# often more valued than readability.
+Style/Semicolon:
   Exclude:
-    - 'spec/**/*'
+    - 'spec/**/*.rb'
 
-Style/HashSyntax:
-  EnforcedShorthandSyntax: always
+# Just always use `raise` and stop thinking about it.
+Style/SignalException:
+  EnforcedStyle: only_raise
 
-# https://rubocop.readthedocs.io/en/latest/cops_style/
-Style/HashTransformKeys:
+# Single line method definitions are totally fine, and often more readable, consider:
+#    class WidgetsPolicy
+#      def create?; false; end
+#      def index?;  true;  end
+#      def show?;   true;  end
+#      def update?; false; end
+#      def delete?; false; end
+#    end
+Style/SingleLineMethods:
   Enabled: false
 
-# https://rubocop.readthedocs.io/en/latest/cops_style/
-Style/HashTransformValues:
-  Enabled: false
+# Just always use double quotes and stop thinking about it.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
 
-Metrics/AbcSize:
-  Max: 18
-  Exclude:
-    - 'spec/**/*'
-
-Metrics/ClassLength:
-  Exclude:
-    - 'spec/**/*'
-
-Naming/MemoizedInstanceVariableName:
-  EnforcedStyleForLeadingUnderscores: optional
-
-Performance/Casecmp:
-  Enabled: false
-
-Rails/SquishedSQLHeredocs:
-  Enabled: false
-
-Rails/ApplicationRecord:
-  Exclude:
-    - 'db/migrate/**'
-
-# we don't require using Rails.logger in lib, as it often doesn't go where
-# we'd want for the code that lives there, or otherwise isn't even available
-Rails/Output:
-  Exclude:
-    - 'lib/**/*'
-
-Style/BarePercentLiterals:
-  EnforcedStyle: percent_q
-
-Style/DoubleNegation:
-  Enabled: false
-
-Style/EmptyMethod:
-  Enabled: false
-
-Style/NumericPredicate:
-  Enabled: false
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
 
 Style/TrivialAccessors:
   AllowPredicates: true
-
-RSpec:
-  Language:
-    Expectations:
-      - assert_match
-
-RSpec/MultipleExpectations:
-  Max: 10
-
-RSpec/ExampleLength:
-  Max: 30
-
-Rails/LexicallyScopedActionFilter:
-  Exclude:
-    - 'app/controllers/application_controller.rb'
-
-RSpec/RepeatedExample:
-  Exclude:
-    - 'spec/policies/**'
-
-RSpec/MultipleMemoizedHelpers:
-  Max: 10
-
-FactoryBot/SyntaxMethods:
-  Enabled: false


### PR DESCRIPTION
I think this makes it easier to review what configuration we're actually using - the sorting priority is:

1. document start marker
2. `plugins`
3. base config properties such as `inherit_gem`
4. everything else, alphabetically but ignoring `:` and newline characters so that plugin configs are put before their cops

<details>
<summary>This is the script I have used to do the sorting</summary>

```ruby
class SortRubocopConfig
  # @param [String] config_file_path
  def self.run(config_file_path)
    new(config_file_path).sort!
  end

  # @param [String] config_file_path
  def initialize(config_file_path)
    # @type [String]
    @config_file_path = config_file_path

    # @type [Hash]
    @sections = {}

    parse_sections
  end

  def sort!
    sorted_sections = @sections.sort_by do |k, _|
      [
        # document start marker
        k == "---\n" ? -1 : 0,
        # plugins list
        k == "plugins:\n" ? -1 : 0,
        # base config properties (i.e "inherit_gem")
        k[0].downcase == k[0] ? -1 : 0,
        # namespaces
        # k.include?("/") ? 1 : 0,
        # everything else without colons or newlines so that plugin config will be
        # put before cop config, since colons are alphabetically smaller than slashes
        k.sub(/:\s*\z/, "")
      ]
    end

    joined = sorted_sections.map { |_, lines| lines.join }.join("\n")

    # make sure there isn't a blank line after the start marker to keep prettier happy
    File.write(@config_file_path, joined.gsub("---\n\n", "---\n"))
  end

  private

  def parse_sections
    section_name = ""
    section_lines = []

    File.readlines(@config_file_path).each do |line|
      # skip empty lines entirely
      next if line.strip.empty?

      # if the line does not start with a space, the previous section (if there
      # is one) must have finished since YAML is indentation based
      unless line.start_with?(" ")
        unless section_name.empty?
          add_section(section_name, section_lines)

          section_name = ""
          section_lines = []
        end

        # if the line is not a comment, it must be the start of the section
        unless line.start_with?("#")
          section_name = line

          puts "found section #{section_name}"
        end
      end

      section_lines << line
    end

    # add the last section we were parsing
    add_section(section_name, section_lines) unless section_name.empty?
  end

  # @param [String] name
  # @param [Array<String>] lines
  def add_section(name, lines)
    raise "duplicate section #{name}" if @sections.key?(name)

    @sections[name] = lines
  end
end

SortRubocopConfig.run("./.rubocop.yml")
```
</details>