### PR TITLE
feat: lock babel to v7

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -92,6 +92,8 @@ end
 TEMPLATE_CONFIG = Config.new
 TERMINAL = Terminal.new
 
+BABEL_MAJOR_VERSION = "7".freeze
+
 # We need the major version of 'jest' and '@types/jest' to match so we
 # can only upgrade jest when there are compatible versions available
 JEST_MAJOR_VERSION = "30".freeze

--- a/variants/frontend-base-typescript/template.rb
+++ b/variants/frontend-base-typescript/template.rb
@@ -10,18 +10,18 @@ end
 
 remove_file "app/frontend/packs/hello_typescript.ts"
 
-types_packages = %w[
+types_packages = %W[
   rails__actioncable
   rails__activestorage
   rails__ujs
   turbolinks
   dotenv-webpack
   webpack-env
-  babel__core
+  babel__core@#{BABEL_MAJOR_VERSION}
   node@24
 ].map { |name| "@types/#{name}" }
 
-add_js_dependencies types_packages + %w[@babel/preset-typescript typescript@5]
+add_js_dependencies types_packages + %W[@babel/preset-typescript@#{BABEL_MAJOR_VERSION} typescript@5]
 add_js_dependencies %w[
   @stylistic/eslint-plugin-ts@3
   @typescript-eslint/eslint-plugin

--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -20,10 +20,10 @@ run "rails shakapacker:install"
 
 # install dependencies for babel and webpack
 add_js_dependencies [
-  "@babel/core",
-  "@babel/plugin-transform-runtime",
-  "@babel/preset-env",
-  "@babel/runtime",
+  "@babel/core@#{BABEL_MAJOR_VERSION}",
+  "@babel/plugin-transform-runtime@#{BABEL_MAJOR_VERSION}",
+  "@babel/preset-env@#{BABEL_MAJOR_VERSION}",
+  "@babel/runtime@#{BABEL_MAJOR_VERSION}",
   "babel-loader",
   "compression-webpack-plugin",
   "css-loader",

--- a/variants/frontend-react/template.rb
+++ b/variants/frontend-react/template.rb
@@ -13,8 +13,8 @@ gsub_file! "app/frontend/test/stimulus/controllers/add_class_controller.test.js"
            "'@testing-library/dom'",
            "'@testing-library/react'"
 
-add_js_dependencies %w[
-  @babel/preset-react
+add_js_dependencies %W[
+  @babel/preset-react@#{BABEL_MAJOR_VERSION}
   babel-plugin-transform-react-remove-prop-types
   react
   react-dom

--- a/variants/frontend-stimulus-typescript/template.rb
+++ b/variants/frontend-stimulus-typescript/template.rb
@@ -1,6 +1,6 @@
 source_paths.unshift(File.dirname(__FILE__))
 
-add_js_dependencies ["@babel/plugin-transform-typescript"]
+add_js_dependencies ["@babel/plugin-transform-typescript@#{BABEL_MAJOR_VERSION}"]
 add_js_dependencies ["@types/jest@#{JEST_MAJOR_VERSION}"], type: :dev
 
 copy_file "eslint.config.js", force: true


### PR DESCRIPTION
Shakapacker does not [support Babel v8 yet](https://github.com/shakacode/shakapacker/issues/1163), so this locks us to v7