### PR TITLE
chore: update `concurrent-ruby` for security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.0.1)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     drb (2.2.3)
     i18n (1.14.8)


### PR DESCRIPTION
Addresses GHSA-6wx8-w4f5-wwcr
Addresses GHSA-h8w8-99g7-qmvj
Addresses GHSA-wv3x-4vxv-whpp