### PR TITLE
fix: ignore advisories

### DIFF
--- a/variants/backend-base/.osv-detector.yml
+++ b/variants/backend-base/.osv-detector.yml
@@ -1,2 +1,4 @@
 ignore:
+  - GHSA-8988-4f7v-96qf # OpenTelemetry Core: Unbounded memory allocation in W3C Baggage propagation
+  - GHSA-h67p-54hq-rp68 # JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases
   - GHSA-w5hq-g745-h8pq # uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided


### PR DESCRIPTION
- GHSA-8988-4f7v-96qf is due to `lighthouse` using an old version of `@sentry/node` which [I've upgraded](https://github.com/GoogleChrome/lighthouse/pull/17079), we're just waiting for a release on
- GHSA-h67p-54hq-rp68 is due to a dependency of Jest - I have done a [backport to v3](https://github.com/nodeca/js-yaml/pull/761) which I'm hoping will get landed...