### PR TITLE
feat: remove more unneeded rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,11 +38,6 @@ AllCops:
 FactoryBot/SyntaxMethods:
   Enabled: false
 
-# We want you to put a blank line between method definitions, the only exception being
-# if you're defining a bunch of single-line methods as above.
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
-
 # We think that:
 #   array = [
 #     :value
@@ -166,10 +161,6 @@ RSpec/RepeatedExample:
 Rails:
   Enabled: true
 
-Rails/ApplicationRecord:
-  Exclude:
-    - 'db/migrate/**'
-
 Rails/LexicallyScopedActionFilter:
   Exclude:
     - 'app/controllers/application_controller.rb'
@@ -239,10 +230,6 @@ Style/NumericPredicate:
 Style/SafeNavigation:
   Enabled: false
 
-# Just always use `raise` and stop thinking about it.
-Style/SignalException:
-  EnforcedStyle: only_raise
-
 # Single line method definitions are totally fine, and often more readable, consider:
 #    class WidgetsPolicy
 #      def create?; false; end
@@ -260,6 +247,3 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
-
-Style/TrivialAccessors:
-  AllowPredicates: true

--- a/variants/backend-base/rubocop.yml.tt
+++ b/variants/backend-base/rubocop.yml.tt
@@ -21,11 +21,6 @@ AllCops:
 FactoryBot/SyntaxMethods:
   Enabled: false
 
-# We want you to put a blank line between method definitions, the only exception being
-# if you're defining a bunch of single-line methods as above.
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
-
 # We think that:
 #   array = [
 #     :value
@@ -130,12 +125,6 @@ Naming/AccessorMethodName:
   Exclude:
     - 'app/policies/**/*_policy.rb'
 
-Naming/FileName:
-  Exclude:
-    - '**/Gemfile'
-    - '**/Rakefile'
-    - '**/Berksfile'
-
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional
 
@@ -171,10 +160,6 @@ RSpec/RepeatedExample:
 # https://github.com/bbatsov/rubocop#rails
 Rails:
   Enabled: true
-
-Rails/ApplicationRecord:
-  Exclude:
-    - 'db/migrate/**'
 
 # Rubocop doesn't like using `post("/", {}, {})` and instead wants to use the keyword variant of these
 # methods, but often brevity is more important than readability in specs.
@@ -264,10 +249,6 @@ Style/Semicolon:
   Exclude:
     - 'spec/**/*.rb'
 
-# Just always use `raise` and stop thinking about it.
-Style/SignalException:
-  EnforcedStyle: only_raise
-
 # Single line method definitions are totally fine, and often more readable, consider:
 #    class WidgetsPolicy
 #      def create?; false; end
@@ -285,6 +266,3 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
-
-Style/TrivialAccessors:
-  AllowPredicates: true


### PR DESCRIPTION
Turns out these too all match the defaults so we might as well omit them to make the config even smaller