### PR TITLE
fix: have `shakapacker` install webpack

### DIFF
--- a/variants/frontend-base/template.rb
+++ b/variants/frontend-base/template.rb
@@ -16,7 +16,7 @@ remove_dir "app/assets/images"
 # ensure our preferred js package manager is specified before running external tooling
 package_json.record_package_manager!
 
-run "rails shakapacker:install"
+run "rails shakapacker:install[webpack]"
 
 # install dependencies for babel and webpack
 add_js_dependencies [


### PR DESCRIPTION
The default bundler was changed to Rspack in [v10.2.0](https://github.com/shakacode/shakapacker/blob/main/CHANGELOG.md#v1020---july-3-2026) so we need to explicitly ask for webpack to be installed