### PR TITLE
feat: reject missing users in generated Pundit policies

### DIFF
--- a/variants/pundit/spec/policies/application_policy_spec.rb
+++ b/variants/pundit/spec/policies/application_policy_spec.rb
@@ -9,7 +9,17 @@ RSpec.describe ApplicationPolicy, type: :policy do
     "REPLACE_ME_WITH_REAL_USER"
   end
 
+  it "rejects a missing policy user" do
+    expect { policy.new(nil, :record) }.to raise_error(Pundit::NotAuthorizedError, "must be logged in")
+  end
+
   permissions ".scope" do
+    it "rejects a missing scope user" do
+      expect do
+        ApplicationPolicy::Scope.new(nil, scope)
+      end.to raise_error(Pundit::NotAuthorizedError, "must be logged in")
+    end
+
     it { expect { ApplicationPolicy::Scope.new(user, scope).resolve }.to raise_error(NotImplementedError) }
   end
 

--- a/variants/pundit/template.rb
+++ b/variants/pundit/template.rb
@@ -14,6 +14,20 @@ run "rails g pundit:policy example"
 # For now, we're just going to stick with the more traditional error for this situation
 gsub_file! "app/policies/application_policy.rb", "raise NoMethodError", "raise NotImplementedError"
 
+insert_into_file! "app/policies/application_policy.rb", after: /^  def initialize\(user, record\)\n/ do
+  <<-RUBY
+    raise Pundit::NotAuthorizedError, "must be logged in" if user.nil?
+
+  RUBY
+end
+
+insert_into_file! "app/policies/application_policy.rb", after: /^    def initialize\(user, scope\)\n/ do
+  <<-RUBY
+      raise Pundit::NotAuthorizedError, "must be logged in" if user.nil?
+
+  RUBY
+end
+
 copy_file "spec/policies/example_policy_spec.rb", force: true
 copy_file "spec/policies/application_policy_spec.rb", force: true
 


### PR DESCRIPTION
## Summary

- reject missing users in generated `ApplicationPolicy` and `ApplicationPolicy::Scope` constructors
- add focused policy and scope regression coverage

## Testing

- generated a fresh Rails 8.1.3 app with the repository basic configuration
- focused policy specs: 10 examples, 0 failures
- full generated app specs: 25 examples, 0 failures, 5 expected pending examples
- generated app RuboCop, Brakeman, ESLint, Prettier, Stylelint, and Jest
- root repository RuboCop, Prettier, and `git diff --check`

The official generated-app check reached `osv-detector`, which is not installed locally; the unchanged baseline stops at the same environment gate.

Closes #483
