### PR TITLE
feat: use `CANONICAL_HOSTNAME` for action mailer domain stuff

### DIFF
--- a/variants/backend-base/config/environments/production.rb
+++ b/variants/backend-base/config/environments/production.rb
@@ -24,11 +24,11 @@ gsub_file! "config/environments/production.rb",
            'config.action_mailer.default_url_options = { host: "example.com" }',
            <<~RUBY
              config.action_mailer.default_url_options = {
-               host: "#{TEMPLATE_CONFIG.production_hostname}",
+               host: ENV.fetch("CANONICAL_HOSTNAME"),
                protocol: "https"
              }
 
-             config.action_mailer.asset_host = "https://#{TEMPLATE_CONFIG.production_hostname}"
+             config.action_mailer.asset_host = ENV.fetch("CANONICAL_HOSTNAME")
            RUBY
 gsub_file! "config/environments/production.rb",
            <<-RUBY,
@@ -50,7 +50,7 @@ gsub_file! "config/environments/production.rb",
     user_name: ENV.fetch("SMTP_USERNAME"),
     password: ENV.fetch("SMTP_PASSWORD"),
     authentication: "login",
-    domain: "#{TEMPLATE_CONFIG.production_hostname}"
+    domain: ENV.fetch("CANONICAL_HOSTNAME")
   }
 RUBY
 

--- a/variants/backend-base/config/environments/staging.rb.tt
+++ b/variants/backend-base/config/environments/staging.rb.tt
@@ -1,13 +1,5 @@
-# Staging configuration is identical to production, with some overrides
-# for hostname, etc.
-
 require_relative "production"
 
 Rails.application.configure do
-  config.action_mailer.default_url_options = {
-    host: "<%= TEMPLATE_CONFIG.staging_hostname %>",
-    protocol: "https"
-  }
-  config.action_mailer.asset_host = "https://<%= TEMPLATE_CONFIG.staging_hostname %>"
-  config.action_mailer.smtp_settings[:domain] = "<%= TEMPLATE_CONFIG.staging_hostname %>"
+  # put any differences to production in here as necessary
 end


### PR DESCRIPTION
I don't feel like there's a reason why we shouldn't use this variable as the default, since it's very rare for us to have a different assets host, and this way changing the domain for an application shouldn't require any code changes