### PR TITLE
fix: pin `json` to v2

### DIFF
--- a/variants/backend-base/Gemfile.tt
+++ b/variants/backend-base/Gemfile.tt
@@ -75,3 +75,6 @@ group :test do
   gem "selenium-webdriver"
   gem "simplecov", require: false
 end
+
+# TODO: you can hopefully remove this once https://github.com/rails/rails/pull/58601 is released
+gem "json", "~> 2.0"


### PR DESCRIPTION
While @byroot has done great work in ensuring the ecosystem is compatible with `json` v3, it seems like a few gems still need to catch-up - notably, both [Rails](https://github.com/rails/rails/pull/58601) and [Faraday](https://github.com/lostisland/faraday/pull/1687) have not yet released their compatibility fixes.

Interestingly only our `devise` variant actually fails, but in an internal app with 100% coverage I only needed to patch Rails & Faraday to have everything seemingly working and `devise` does not seem to use JSON directly itself.

I think overall it's better to play it safe and pin ourselves to JSON v2 at least until Rails has released their patch